### PR TITLE
Implement features, MSC metrics, CLI and docs

### DIFF
--- a/ogum-ml-lite/LICENSE
+++ b/ogum-ml-lite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ogum ML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -1,5 +1,9 @@
 # Ogum ML Lite
 
+[![CI](https://github.com/huyraestevao/ogum-ml/actions/workflows/ci.yml/badge.svg)](https://github.com/huyraestevao/ogum-ml/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Open In Colab](https://colab.research.googleusercontent.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huyraestevao/ogum-ml/blob/main/ogum-ml-lite/notebooks/ogum_ml_demo.ipynb)
+
 Bootstrap do toolkit **Ogum ML Lite** para cálculos de θ(Ea) e Master Sintering
 Curves (MSC) compatíveis com o ecossistema Ogum 6.4. O objetivo é disponibilizar
 um pacote Python leve, fácil de usar em Google Colab e pronto para integrações
@@ -9,60 +13,79 @@ com pipelines de ML.
 
 - **θ(Ea) rápido**: cálculo direto a partir de ensaios de sinterização via
   `OgumLite.compute_theta_table` ou CLI.
-- **MSC Colab-friendly**: geração de curvas mestras sem dependências pesadas.
-- **Compatibilidade**: nomes de colunas (`time_s`, `temperature_C`,
-  `densification`, `datatype`) e estágios alinhados com o Ogum 6.4 e com as
-  diretrizes do repositório [ogumsoftware](https://github.com/huyraestevao/ogumsoftware).
+- **MSC robusta**: métrica segmentada (55–70–90%) para avaliar o colapso das
+  curvas por amostra.
+- **Compatibilidade**: nomes de colunas (`sample_id`, `time_s`, `temp_C`,
+  `rho_rel`) alinhados com Ogum 6.4 e notebooks do repositório
+  [ogumsoftware](https://github.com/huyraestevao/ogumsoftware).
 - **Pronto para ML**: módulo `ml_hooks` reservado para integração de pipelines e
-  `features` com TODOs explícitos.
+  `features` com engenharia de atributos por amostra.
 
 ## Instalação
 
 ```bash
 conda env create -f environment.yml
 conda activate ogum-ml-lite
-```
 
-Para instalar em modo editável:
-
-```bash
 pip install -e .[dev]
 ```
 
-## Uso rápido
+## Formato de dados (long)
 
-### CLI
+Os ensaios devem estar em formato *long* com uma linha por instante de tempo:
 
-Calcular θ(Ea) e exportar CSV:
+| sample_id | time_s | temp_C | rho_rel |
+|-----------|--------|--------|---------|
+| S0        | 0.0    | 25.0   | 0.10    |
+| S0        | 60.0   | 215.0  | 0.24    |
+| S1        | 0.0    | 25.0   | 0.08    |
+| S1        | 60.0   | 210.0  | 0.21    |
 
-```bash
-python -m ogum_lite.cli theta --input ensaios.csv --ea "200,300,400" --outdir exports/
-```
+Outras colunas (pressão, estágio, etc.) podem ser preservadas — apenas os
+nomes acima são obrigatórios para o pipeline mínimo.
 
-Gerar MSC, exportando CSV e PNG:
-
-```bash
-python -m ogum_lite.cli msc --input ensaios.csv --ea 200 --png msc.png --csv msc.csv
-```
-
-Abrir interface Gradio:
+## Uso rápido (CLI)
 
 ```bash
+# Engenharia de atributos por amostra
+python -m ogum_lite.cli features \
+  --input data/ensaios_long.csv \
+  --ea "200,300,400" \
+  --output exports/features.csv
+
+# Tabelas θ(Ea) por ponto (formato longo)
+python -m ogum_lite.cli theta \
+  --input data/ensaios_long.csv \
+  --ea "200,300,400" \
+  --outdir exports/
+
+# Curva Mestra com métrica segmentada robusta
+python -m ogum_lite.cli msc \
+  --input data/ensaios_long.csv \
+  --ea "200,300,400" \
+  --metric segmented \
+  --csv exports/msc_curve.csv \
+  --png exports/msc.png
+
+# UI experimental em Gradio
 python -m ogum_lite.cli ui
 ```
 
-### Fluxo em Colab
+O comando `msc` imprime a tabela de métricas (`mse_global`, `mse_segmented`,
+`mse_0.55_0.70`, `mse_0.70_0.90`), destaca o melhor Ea e exporta a curva mestra
+normalizada.
 
-1. Clone ou sincronize o repositório na sessão.
-2. Instale dependências mínimas (`pip install ogum-ml-lite` via arquivo wheel ou
-   modo editável).
-3. Carregue datasets com as colunas padronizadas e utilize `OgumLite` para
-   realizar cortes (`select_datatype`, `cut_by_time`, `baseline_shift`), calcular
-   θ(Ea) e gerar MSC.
-4. Utilize os notebooks em `notebooks/` como referência para manter o estilo de
-   documentação e organização do Ogum 6.4.
+## Fluxo em Colab
 
-### Integração com Ogum 6.4
+1. Abra o notebook de exemplo clicando no badge **Open In Colab** acima.
+2. Execute a primeira célula para gerar um CSV sintético ou carregue o seu
+   arquivo (`sample_id,time_s,temp_C,rho_rel`).
+3. Use as células seguintes para gerar `features.csv`, `msc_curve.csv` e o
+   gráfico `msc.png` diretamente no Colab.
+4. Opcional: rode `python -m ogum_lite.cli ui` em uma célula para acessar a UI
+   interativa.
+
+## Integração com Ogum 6.4
 
 - Mesma nomenclatura de colunas e estágios.
 - Resultados (θ(Ea) e MSC) podem ser exportados em CSV para ingestão no Ogum 6.4.
@@ -86,11 +109,17 @@ CI via GitHub Actions executa o mesmo pipeline de lint e testes.
 ```
 ogum_lite/
   cli.py          # CLI com subcomandos features, theta, msc, ui
-  theta_msc.py    # Classe principal OgumLite
-  features.py     # TODOs para métricas derivadas
-  ml_hooks.py     # Pontos de integração com ML
+  features.py     # Engenharia de atributos por amostra
+  theta_msc.py    # θ(Ea), Master Sintering Curve e métricas robustas
+  ml_hooks.py     # Stubs para integração futura com pipelines de ML
 notebooks/
-  README.md       # Diretrizes para notebooks alinhados ao Ogum 6.4
+  ogum_ml_demo.ipynb  # Fluxo mínimo em Colab com CLI embutida
 tests/
-  test_smoke.py   # Smoke test com dados sintéticos
+  test_smoke.py, test_features.py, test_msc.py
 ```
+
+## Roadmap (ml_hooks)
+
+- Registrar pipelines de classificação/regressão (`register_pipeline`).
+- Carregar modelos treinados (joblib/MLflow) via `load_pipeline`.
+- Padronizar contratos de entrada/saída para integração com Ogum completo.

--- a/ogum-ml-lite/notebooks/ogum_ml_demo.ipynb
+++ b/ogum-ml-lite/notebooks/ogum_ml_demo.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02c77756",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Synthetic dataset with two samples\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "time = np.linspace(0, 600, 121)\n",
+    "frames = []\n",
+    "for idx, shift in enumerate([0.0, 18.0]):\n",
+    "    rho = 1 - np.exp(-(time + shift) / 180)\n",
+    "    temp = 25 + 3.2 * time + idx * 6\n",
+    "    frames.append(\n",
+    "        pd.DataFrame(\n",
+    "            {\n",
+    "                \"sample_id\": f\"S{idx}\",\n",
+    "                \"time_s\": time,\n",
+    "                \"temp_C\": temp,\n",
+    "                \"rho_rel\": rho,\n",
+    "            }\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "df_long = pd.concat(frames, ignore_index=True)\n",
+    "df_long.to_csv(\"synthetic_long.csv\", index=False)\n",
+    "df_long.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d9de8c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m ogum_lite.cli features --input synthetic_long.csv --ea \"200,300,400\" --output demo_features.csv --print\n",
+    "\n",
+    "import pandas as pd\n",
+    "pd.read_csv(\"demo_features.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1856e1d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m ogum_lite.cli msc --input synthetic_long.csv --ea \"200,300,400\" --csv demo_msc.csv --png demo_msc.png\n",
+    "\n",
+    "import pandas as pd\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "pd.read_csv(\"demo_msc.csv\").head()\n",
+    "Image(\"demo_msc.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5795bf12",
+   "metadata": {},
+   "source": [
+    "## Próximos passos\n",
+    "\n",
+    "1. Substitua `synthetic_long.csv` pelo CSV dos seus ensaios no formato longo (`sample_id,time_s,temp_C,rho_rel`).\n",
+    "2. Ajuste a lista de energias de ativação (`--ea`) conforme necessário.\n",
+    "3. Explore a interface `python -m ogum_lite.cli ui` para testar rapidamente outros filtros e métricas."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ogum-ml-lite/ogum_lite/__init__.py
+++ b/ogum-ml-lite/ogum_lite/__init__.py
@@ -1,5 +1,27 @@
 """Ogum Lite package initialization."""
 
-from .theta_msc import OgumLite
+from .features import (
+    aggregate_timeseries,
+    build_feature_table,
+    finite_diff,
+    theta_features,
+)
+from .theta_msc import (
+    R_GAS_CONSTANT,
+    MasterCurveResult,
+    OgumLite,
+    build_master_curve,
+    score_activation_energies,
+)
 
-__all__ = ["OgumLite"]
+__all__ = [
+    "MasterCurveResult",
+    "OgumLite",
+    "R_GAS_CONSTANT",
+    "aggregate_timeseries",
+    "build_feature_table",
+    "build_master_curve",
+    "finite_diff",
+    "score_activation_energies",
+    "theta_features",
+]

--- a/ogum-ml-lite/ogum_lite/cli.py
+++ b/ogum-ml-lite/ogum_lite/cli.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import argparse
-import json
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Iterable, List
 
 import gradio as gr
+import matplotlib.pyplot as plt
 import pandas as pd
 
-from .theta_msc import OgumLite
+from .features import build_feature_table
+from .theta_msc import OgumLite, score_activation_energies
 
 
 def parse_ea_list(raw: str) -> List[float]:
@@ -25,21 +28,34 @@ def parse_ea_list(raw: str) -> List[float]:
 
 
 def cmd_features(args: argparse.Namespace) -> None:
-    """Placeholder for the upcoming feature extraction routines."""
+    dataframe = pd.read_csv(args.input)
+    features_df = build_feature_table(
+        dataframe,
+        args.ea,
+        group_col=args.group_col,
+        t_col=args.time_column,
+        temp_col=args.temperature_column,
+        y_col=args.y_column,
+    )
 
-    payload = {
-        "status": "not-implemented",
-        "message": "Feature extraction pipeline will be added in a future release.",
-        "requested_metrics": args.metrics,
-    }
-    print(json.dumps(payload, indent=2))
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    features_df.to_csv(output_path, index=False)
+
+    print(f"Feature table saved to {output_path}")
+    if args.print:
+        print(features_df.to_string(index=False))
 
 
 def cmd_theta(args: argparse.Namespace) -> None:
     ogum = OgumLite()
     ogum.load_csv(args.input)
 
-    theta_df = ogum.compute_theta_table(args.ea)
+    theta_df = ogum.compute_theta_table(
+        args.ea,
+        temperature_column=args.temperature_column,
+        time_column=args.time_column,
+    )
 
     outdir = Path(args.outdir)
     outdir.mkdir(parents=True, exist_ok=True)
@@ -52,75 +68,146 @@ def cmd_theta(args: argparse.Namespace) -> None:
 
 
 def cmd_msc(args: argparse.Namespace) -> None:
-    ogum = OgumLite()
-    ogum.load_csv(args.input)
+    dataframe = pd.read_csv(args.input)
+    normalize_theta = None if args.normalize_theta == "none" else args.normalize_theta
 
-    msc_df = ogum.build_msc(
-        activation_energy=args.ea,
-        densification_column=args.densification_column,
-        temperature_column=args.temperature_column,
-        time_column=args.time_column,
+    summary, best_result, _ = score_activation_energies(
+        dataframe,
+        args.ea,
+        metric=args.metric,
+        group_col=args.group_col,
+        t_col=args.time_column,
+        temp_col=args.temperature_column,
+        y_col=args.y_column,
+        normalize_theta=normalize_theta,
+    )
+
+    print(summary.to_string(index=False))
+    print(
+        "best_Ea_kJ_mol={:.3f} mse_global={:.6f} mse_segmented={:.6f}".format(
+            best_result.activation_energy,
+            best_result.mse_global,
+            best_result.mse_segmented,
+        )
     )
 
     if args.csv:
-        msc_df.to_csv(args.csv, index=False)
-        print(f"MSC exported to {args.csv}")
+        args.csv.parent.mkdir(parents=True, exist_ok=True)
+        best_result.curve.to_csv(args.csv, index=False)
+        print(f"MSC curve exported to {args.csv}")
 
     if args.png:
-        ax = ogum.plot_msc(msc_df)
-        ax.figure.savefig(args.png, dpi=150, bbox_inches="tight")
-        print(f"MSC figure saved to {args.png}")
-
-    if not args.csv and not args.png:
-        print(msc_df.to_string(index=False))
+        fig, ax = plt.subplots()
+        for sample_id, sample_df in best_result.per_sample.groupby(args.group_col):
+            ax.plot(
+                sample_df["theta"],
+                sample_df["densification"],
+                alpha=0.4,
+                linewidth=1.0,
+                label=str(sample_id),
+            )
+        ax.plot(
+            best_result.curve["theta_mean"],
+            best_result.curve["densification"],
+            color="black",
+            linewidth=2.0,
+            label="Mean MSC",
+        )
+        ax.set_xlabel(r"$\Theta(E_a)$ (normalised)")
+        ax.set_ylabel("Densification")
+        title = (
+            f"MSC collapse (Ea={best_result.activation_energy:.1f} kJ/mol) "
+            f"[metric={args.metric}]"
+        )
+        ax.set_title(title)
+        ax.grid(True, alpha=0.3)
+        handles, labels = ax.get_legend_handles_labels()
+        if len(labels) > 10:
+            ax.legend(handles[:1] + [handles[-1]], ["samples", "Mean MSC"], loc="best")
+        else:
+            ax.legend(loc="best")
+        args.png.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(args.png, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"MSC plot saved to {args.png}")
 
 
 def launch_ui() -> None:
     """Launch a minimalist Gradio UI for θ(Ea) and MSC exploration."""
 
-    ogum = OgumLite()
-
-    def compute_theta(file: gr.File, ea_list: str) -> pd.DataFrame:
+    def process(
+        file: gr.File,
+        t_min: float | None,
+        t_max: float | None,
+        shift: float,
+        scale: float,
+        ea_list: str,
+        metric: str,
+    ) -> tuple[pd.DataFrame, gr.File | None, gr.File | None, gr.File | None]:
         dataframe = pd.read_csv(file.name)
-        ogum.data = dataframe
+        if t_min is not None:
+            dataframe = dataframe[dataframe["time_s"] >= t_min]
+        if t_max is not None:
+            dataframe = dataframe[dataframe["time_s"] <= t_max]
+
+        dataframe = dataframe.copy()
+        dataframe["rho_rel"] = (dataframe["rho_rel"] + shift) * scale
+
         ea_values = parse_ea_list(ea_list)
-        return ogum.compute_theta_table(ea_values)
+        summary, best_result, _ = score_activation_energies(
+            dataframe,
+            ea_values,
+            metric=metric,
+        )
 
-    def compute_msc(file: gr.File, ea_value: float) -> pd.DataFrame:
-        dataframe = pd.read_csv(file.name)
-        ogum.data = dataframe
-        return ogum.build_msc(activation_energy=ea_value)
+        tmpdir = Path(tempfile.mkdtemp(prefix="ogum_ml_ui_"))
+
+        summary_path = tmpdir / "best_ea_mse.csv"
+        summary.to_csv(summary_path, index=False)
+
+        curve_path = tmpdir / "msc_curve.csv"
+        best_result.curve.to_csv(curve_path, index=False)
+
+        zip_path = tmpdir / "theta_curves.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for sample_id, sample_df in best_result.per_sample.groupby("sample_id"):
+                buffer = sample_df.to_csv(index=False).encode("utf-8")
+                zf.writestr(f"theta_{sample_id}.csv", buffer)
+
+        return (
+            summary,
+            gr.File.update(value=str(summary_path)),
+            gr.File.update(value=str(curve_path)),
+            gr.File.update(value=str(zip_path)),
+        )
 
     with gr.Blocks() as demo:
         gr.Markdown("## Ogum ML Lite – θ(Ea) & MSC")
 
-        with gr.Tab("θ(Ea)"):
-            file_theta = gr.File(label="Ensaios CSV")
-            ea_input = gr.Textbox(label="Ea (kJ/mol)", value="200, 300")
-            theta_button = gr.Button("Calcular θ(Ea)")
-            theta_output = gr.Dataframe()
-            theta_button.click(
-                compute_theta,
-                inputs=[file_theta, ea_input],
-                outputs=theta_output,
-            )
+        file_input = gr.File(label="Ensaios CSV (long format)")
+        with gr.Row():
+            t_min = gr.Number(label="t_min (s)", value=None)
+            t_max = gr.Number(label="t_max (s)", value=None)
+            shift = gr.Number(label="shift", value=0.0)
+            scale = gr.Number(label="scale", value=1.0)
+        ea_box = gr.Textbox(label="Ea list (kJ/mol)", value="200,300,400")
+        metric_radio = gr.Radio(
+            label="Métrica de colapso",
+            choices=["segmented", "global"],
+            value="segmented",
+        )
 
-        with gr.Tab("MSC"):
-            file_msc = gr.File(label="Ensaios CSV")
-            ea_slider = gr.Slider(
-                label="Ea (kJ/mol)",
-                value=200,
-                minimum=50,
-                maximum=600,
-                step=10,
-            )
-            msc_button = gr.Button("Gerar MSC")
-            msc_output = gr.Dataframe()
-            msc_button.click(
-                compute_msc,
-                inputs=[file_msc, ea_slider],
-                outputs=msc_output,
-            )
+        process_button = gr.Button("Calcular MSC")
+        summary_df = gr.Dataframe(label="Resumo θ(Ea)")
+        summary_file = gr.File(label="best_ea_mse.csv")
+        curve_file = gr.File(label="msc_curve.csv")
+        theta_zip = gr.File(label="theta_curves.zip")
+
+        process_button.click(
+            process,
+            inputs=[file_input, t_min, t_max, shift, scale, ea_box, metric_radio],
+            outputs=[summary_df, summary_file, curve_file, theta_zip],
+        )
 
     demo.launch()
 
@@ -134,13 +221,50 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     parser_features = subparsers.add_parser(
-        "features", help="Feature extraction helpers"
+        "features", help="Compute per-sample feature tables"
     )
     parser_features.add_argument(
-        "--metrics",
-        nargs="*",
-        default=[],
-        help="Specific metrics to compute (future use).",
+        "--input",
+        type=Path,
+        required=True,
+        help="CSV longo com colunas sample_id,time_s,temp_C,rho_rel.",
+    )
+    parser_features.add_argument(
+        "--output",
+        type=Path,
+        default=Path("features.csv"),
+        help="Arquivo de saída para a tabela de features.",
+    )
+    parser_features.add_argument(
+        "--ea",
+        type=parse_ea_list,
+        required=True,
+        help="Lista de Ea em kJ/mol (ex.: '200,300,400').",
+    )
+    parser_features.add_argument(
+        "--group-col",
+        default="sample_id",
+        help="Nome da coluna com o identificador da amostra.",
+    )
+    parser_features.add_argument(
+        "--time-column",
+        default="time_s",
+        help="Nome da coluna de tempo (s).",
+    )
+    parser_features.add_argument(
+        "--temperature-column",
+        default="temp_C",
+        help="Nome da coluna de temperatura (°C).",
+    )
+    parser_features.add_argument(
+        "--y-column",
+        default="rho_rel",
+        help="Coluna de densificação relativa (0–1).",
+    )
+    parser_features.add_argument(
+        "--print",
+        action="store_true",
+        help="Imprime a tabela resultante no stdout.",
     )
     parser_features.set_defaults(func=cmd_features)
 
@@ -156,6 +280,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=parse_ea_list,
         required=True,
         help="Comma separated Ea values in kJ/mol (e.g. '200,300,400').",
+    )
+    parser_theta.add_argument(
+        "--time-column",
+        default="time_s",
+        help="Nome da coluna de tempo (s).",
+    )
+    parser_theta.add_argument(
+        "--temperature-column",
+        default="temp_C",
+        help="Nome da coluna de temperatura (°C).",
     )
     parser_theta.add_argument(
         "--outdir",
@@ -179,24 +313,41 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser_msc.add_argument(
         "--ea",
-        type=float,
+        type=parse_ea_list,
         required=True,
-        help="Activation energy (kJ/mol) for the MSC integration.",
+        help="Lista de Ea em kJ/mol para avaliar.",
     )
     parser_msc.add_argument(
-        "--densification-column",
-        default="densification",
-        help="Column name containing densification values.",
+        "--group-col",
+        default="sample_id",
+        help="Nome da coluna com o identificador da amostra.",
     )
     parser_msc.add_argument(
         "--temperature-column",
-        default="temperature_C",
-        help="Column name containing temperatures in Celsius.",
+        default="temp_C",
+        help="Nome da coluna de temperatura (°C).",
     )
     parser_msc.add_argument(
         "--time-column",
         default="time_s",
         help="Column name containing time stamps in seconds.",
+    )
+    parser_msc.add_argument(
+        "--y-column",
+        default="rho_rel",
+        help="Coluna de densificação relativa (0–1).",
+    )
+    parser_msc.add_argument(
+        "--normalize-theta",
+        choices=["minmax", "none"],
+        default="minmax",
+        help="Normalização aplicada antes do colapso MSC.",
+    )
+    parser_msc.add_argument(
+        "--metric",
+        choices=["global", "segmented"],
+        default="segmented",
+        help="Métrica usada para escolher o melhor Ea.",
     )
     parser_msc.add_argument(
         "--csv",

--- a/ogum-ml-lite/ogum_lite/features.py
+++ b/ogum-ml-lite/ogum_lite/features.py
@@ -1,82 +1,250 @@
-"""Feature engineering helpers for sintering datasets."""
+"""Feature engineering helpers for Ogum Lite datasets."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
 import pandas as pd
 
-
-def heating_rate_med(
-    df: pd.DataFrame, temperature_column: str = "temperature_C"
-) -> float:
-    """Median heating rate (placeholder implementation)."""
-
-    # TODO: replace by derivative-based calculation aligned with Ogum 6.4.
-    temps = df[temperature_column].diff().dropna()
-    return temps.median()
+from .theta_msc import R_GAS_CONSTANT
 
 
-def t_max(df: pd.DataFrame, time_column: str = "time_s") -> float:
-    """Return the maximum registered time."""
-
-    # TODO: align with Ogum 6.4 convention (per stage filtering).
-    return float(df[time_column].max())
-
-
-def rho_final(df: pd.DataFrame, densification_column: str = "densification") -> float:
-    """Return the final densification value."""
-
-    # TODO: incorporate corrections applied in ogumsoftware repository.
-    return float(df[densification_column].iloc[-1])
+@dataclass
+class _PreparedTimeseries:
+    time_s: np.ndarray
+    temp_C: np.ndarray
+    y_rel: np.ndarray
 
 
-def time_at_fraction(
-    df: pd.DataFrame,
-    fraction: float,
+def finite_diff(y: np.ndarray, x: np.ndarray) -> np.ndarray:
+    """Compute first-order derivatives using centred finite differences.
+
+    Parameters
+    ----------
+    y:
+        Array with observations evaluated at the positions ``x``.
+    x:
+        Monotonically increasing positions used to estimate the derivative.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array with the same shape as ``y`` containing the derivative ``dy/dx``.
+
+    Notes
+    -----
+    The derivative at the interior points is computed using centred differences,
+    while the boundaries rely on forward/backward first-order schemes.
+    """
+
+    y = np.asarray(y, dtype=float)
+    x = np.asarray(x, dtype=float)
+
+    if y.shape != x.shape:
+        raise ValueError("`y` and `x` must share the same shape")
+
+    if y.size < 2:
+        raise ValueError("At least two samples are required to estimate the derivative")
+
+    if np.any(np.diff(x) <= 0):
+        raise ValueError("Array `x` must be strictly increasing")
+
+    derivative = np.empty_like(y, dtype=float)
+    derivative[1:-1] = (y[2:] - y[:-2]) / (x[2:] - x[:-2])
+    derivative[0] = (y[1] - y[0]) / (x[1] - x[0])
+    derivative[-1] = (y[-1] - y[-2]) / (x[-1] - x[-2])
+    return derivative
+
+
+def _prepare_group(
+    group: pd.DataFrame,
     *,
-    densification_column: str = "densification",
-    time_column: str = "time_s",
-) -> float:
-    """Return the first time when densification reaches ``fraction``."""
+    t_col: str,
+    temp_col: str,
+    y_col: str,
+) -> _PreparedTimeseries:
+    subset = group[[t_col, temp_col, y_col]].dropna()
+    subset = subset.sort_values(t_col)
+    subset = subset.loc[~subset[t_col].duplicated(keep="first")]
 
-    # TODO: replace with interpolation logic from Ogum 6.4 notebooks.
-    mask = df[densification_column] >= fraction
-    if not mask.any():
-        raise ValueError("Fraction never reached in densification data.")
-    return float(df.loc[mask, time_column].iloc[0])
+    return _PreparedTimeseries(
+        time_s=subset[t_col].to_numpy(dtype=float),
+        temp_C=subset[temp_col].to_numpy(dtype=float),
+        y_rel=subset[y_col].to_numpy(dtype=float),
+    )
 
 
-def densification_rate_max(
+def aggregate_timeseries(
     df: pd.DataFrame,
     *,
-    densification_column: str = "densification",
-    time_column: str = "time_s",
-) -> float:
-    """Return the maximum densification rate."""
+    group_col: str = "sample_id",
+    t_col: str = "time_s",
+    temp_col: str = "temp_C",
+    y_col: str = "rho_rel",
+) -> pd.DataFrame:
+    """Aggregate per-sample statistics for long-format sintering datasets.
 
-    # TODO: incorporate smoothing strategy from ogumsoftware.
-    rate = df[densification_column].diff() / df[time_column].diff()
-    return float(rate.max())
+    Parameters
+    ----------
+    df:
+        Long-format dataframe containing the sintering runs.
+    group_col:
+        Column identifying the sample/experiment id.
+    t_col:
+        Column with timestamps in seconds.
+    temp_col:
+        Column with temperatures in Celsius.
+    y_col:
+        Column with relative density or shrinkage fraction (0–1).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Dataframe indexed by ``group_col`` with engineered features per sample.
+    """
+
+    required_columns = {group_col, t_col, temp_col, y_col}
+    missing = required_columns - set(df.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing required columns: {missing_cols}")
+
+    records: list[dict[str, float | str]] = []
+
+    for sample_id, group in df.groupby(group_col):
+        prepared = _prepare_group(group, t_col=t_col, temp_col=temp_col, y_col=y_col)
+
+        time = prepared.time_s
+        temp = prepared.temp_C
+        y_rel = prepared.y_rel
+
+        metrics: dict[str, float | str] = {group_col: sample_id}
+
+        if time.size >= 2:
+            dtemp_dt = finite_diff(temp, time)
+            metrics["heating_rate_med_C_per_s"] = float(np.nanmedian(dtemp_dt))
+
+            dy_dt = finite_diff(y_rel, time)
+            idx_max = int(np.argmax(dy_dt))
+            metrics["dy_dt_max"] = float(dy_dt[idx_max])
+            metrics["T_at_dy_dt_max_C"] = float(temp[idx_max])
+        else:
+            metrics["heating_rate_med_C_per_s"] = float("nan")
+            metrics["dy_dt_max"] = float("nan")
+            metrics["T_at_dy_dt_max_C"] = float("nan")
+
+        metrics["T_max_C"] = float(group[temp_col].max())
+        metrics["y_final"] = float(y_rel[-1]) if y_rel.size else float("nan")
+
+        mask_90 = y_rel >= 0.90
+        if mask_90.any():
+            metrics["t_to_90pct_s"] = float(time[mask_90][0])
+        else:
+            metrics["t_to_90pct_s"] = float("nan")
+
+        records.append(metrics)
+
+    return pd.DataFrame.from_records(records)
 
 
-def temperature_at_rate_max(
-    df: pd.DataFrame,
+def _format_ea_label(value: float) -> str:
+    formatted = ("%g" % value).replace(".", "p")
+    return f"theta_Ea_{formatted}kJ"
+
+
+def theta_features(
+    df_long: pd.DataFrame,
+    ea_kj_list: Iterable[float],
     *,
-    temperature_column: str = "temperature_C",
-    densification_column: str = "densification",
-    time_column: str = "time_s",
-) -> float:
-    """Temperature when densification rate is maximal."""
+    group_col: str = "sample_id",
+    t_col: str = "time_s",
+    temp_col: str = "temp_C",
+    y_col: str = "rho_rel",
+) -> pd.DataFrame:
+    """Compute θ(Ea) integrals per sample for a list of activation energies.
 
-    rate = df[densification_column].diff() / df[time_column].diff()
-    idx = rate.idxmax()
-    return float(df.loc[idx, temperature_column])
+    Parameters
+    ----------
+    df_long:
+        Long-format dataframe with the sintering runs.
+    ea_kj_list:
+        Iterable containing activation energies in kJ/mol.
+    group_col, t_col, temp_col, y_col:
+        Column names describing the long-format structure.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Dataframe with one row per sample and θ(Ea) totals as additional columns.
+    """
+
+    required_columns = {group_col, t_col, temp_col, y_col}
+    missing = required_columns - set(df_long.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing required columns: {missing_cols}")
+
+    ea_values = list(ea_kj_list)
+    if not ea_values:
+        raise ValueError("`ea_kj_list` must contain at least one activation energy")
+
+    records: list[dict[str, float | str]] = []
+
+    for sample_id, group in df_long.groupby(group_col):
+        prepared = _prepare_group(group, t_col=t_col, temp_col=temp_col, y_col=y_col)
+        time = prepared.time_s
+        temp = prepared.temp_C + 273.15
+
+        metrics: dict[str, float | str] = {group_col: sample_id}
+
+        if time.size >= 2:
+            for ea in ea_values:
+                integrand = np.exp(-(ea * 1000.0) / (R_GAS_CONSTANT * temp))
+                theta_total = float(np.trapezoid(integrand, time))
+                metrics[_format_ea_label(ea)] = theta_total
+        else:
+            for ea in ea_values:
+                metrics[_format_ea_label(ea)] = float("nan")
+
+        records.append(metrics)
+
+    return pd.DataFrame.from_records(records)
+
+
+def build_feature_table(
+    df_long: pd.DataFrame,
+    ea_kj_list: Iterable[float],
+    *,
+    group_col: str = "sample_id",
+    t_col: str = "time_s",
+    temp_col: str = "temp_C",
+    y_col: str = "rho_rel",
+) -> pd.DataFrame:
+    """Combine aggregated statistics and θ(Ea) totals for each sample."""
+
+    agg = aggregate_timeseries(
+        df_long,
+        group_col=group_col,
+        t_col=t_col,
+        temp_col=temp_col,
+        y_col=y_col,
+    )
+    theta = theta_features(
+        df_long,
+        ea_kj_list,
+        group_col=group_col,
+        t_col=t_col,
+        temp_col=temp_col,
+        y_col=y_col,
+    )
+    return pd.merge(agg, theta, on=group_col, how="inner")
 
 
 __all__ = [
-    "densification_rate_max",
-    "heating_rate_med",
-    "rho_final",
-    "t_max",
-    "temperature_at_rate_max",
-    "time_at_fraction",
+    "aggregate_timeseries",
+    "build_feature_table",
+    "finite_diff",
+    "theta_features",
 ]

--- a/ogum-ml-lite/ogum_lite/theta_msc.py
+++ b/ogum-ml-lite/ogum_lite/theta_msc.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Dict, Iterable, Literal, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,6 +19,20 @@ import pandas as pd
 from scipy.integrate import cumulative_trapezoid
 
 R_GAS_CONSTANT = 8.314462618  # J/(mol*K)
+
+
+@dataclass
+class MasterCurveResult:
+    """Container with the outcome of a MSC collapse for a given Ea."""
+
+    activation_energy: float
+    curve: pd.DataFrame
+    per_sample: pd.DataFrame
+    mse_global: float
+    mse_segmented: float
+    segment_mse: Dict[Tuple[float, float], float]
+    normalize_theta: Literal["minmax", None]
+    segments: Tuple[Tuple[float, float], ...]
 
 
 @dataclass
@@ -33,9 +47,9 @@ class OgumLite:
 
         ``time_s``
             Time in seconds since the start of the run.
-        ``temperature_C``
+        ``temp_C``
             Process temperature in Celsius.
-        ``densification``
+        ``rho_rel``
             Relative density or shrinkage fraction between 0 and 1.
         ``datatype`` (optional)
             Stage or label to filter datasets (e.g. ``"heating"``).
@@ -124,7 +138,7 @@ class OgumLite:
         return self.data
 
     def baseline_shift(
-        self, column: str = "densification", reference: str = "first"
+        self, column: str = "rho_rel", reference: str = "first"
     ) -> pd.DataFrame:
         """Shift the densification baseline to start at zero.
 
@@ -159,7 +173,7 @@ class OgumLite:
     def compute_theta_table(
         self,
         activation_energies: Iterable[float],
-        temperature_column: str = "temperature_C",
+        temperature_column: str = "temp_C",
         time_column: str = "time_s",
     ) -> pd.DataFrame:
         """Compute the Ogum θ(Ea) table for the provided activation energies.
@@ -198,8 +212,8 @@ class OgumLite:
     def build_msc(
         self,
         activation_energy: float,
-        densification_column: str = "densification",
-        temperature_column: str = "temperature_C",
+        densification_column: str = "rho_rel",
+        temperature_column: str = "temp_C",
         time_column: str = "time_s",
     ) -> pd.DataFrame:
         """Construct a Master Sintering Curve (MSC).
@@ -275,4 +289,241 @@ class OgumLite:
         return self.data
 
 
-__all__ = ["OgumLite", "R_GAS_CONSTANT"]
+def _normalise_theta(theta: np.ndarray, mode: Literal["minmax", None]) -> np.ndarray:
+    if mode is None:
+        return theta
+    if mode == "minmax":
+        theta_min = float(theta.min())
+        theta_max = float(theta.max())
+        scale = theta_max - theta_min
+        if scale <= 0:
+            return np.zeros_like(theta)
+        return (theta - theta_min) / scale
+    raise ValueError("normalize_theta must be 'minmax' or None")
+
+
+def build_master_curve(
+    df_long: pd.DataFrame,
+    activation_energy: float,
+    *,
+    group_col: str = "sample_id",
+    t_col: str = "time_s",
+    temp_col: str = "temp_C",
+    y_col: str = "rho_rel",
+    normalize_theta: Literal["minmax", None] = "minmax",
+    segments: Sequence[Tuple[float, float]] = ((0.55, 0.70), (0.70, 0.90)),
+    grid_size: int = 200,
+) -> MasterCurveResult:
+    """Collapse multiple runs into a MSC and compute error metrics.
+
+    Parameters
+    ----------
+    df_long:
+        Long-format dataframe containing multiple samples identified via
+        ``group_col``.
+    activation_energy:
+        Activation energy in kJ/mol used for the θ(Ea) integration.
+    group_col, t_col, temp_col, y_col:
+        Column names describing the long-format dataset.
+    normalize_theta:
+        Normalisation strategy applied to the cumulative θ arrays prior to the
+        collapse.  ``"minmax"`` scales each curve to [0, 1]; ``None`` keeps the
+        original θ values.
+    segments:
+        Iterable with (lower, upper) densification ranges used to compute the
+        segmented MSE.
+    grid_size:
+        Number of points used to sample the common densification grid.
+
+    Returns
+    -------
+    MasterCurveResult
+        Dataclass containing the collapsed curve, per-sample projections and
+        error metrics.
+    """
+
+    required_columns = {group_col, t_col, temp_col, y_col}
+    missing = required_columns - set(df_long.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing required columns: {missing_cols}")
+
+    if grid_size < 10:
+        raise ValueError("grid_size must be at least 10 to sample the MSC")
+
+    segments_tuple: Tuple[Tuple[float, float], ...] = tuple(
+        (float(seg[0]), float(seg[1])) for seg in segments
+    )
+    if not segments_tuple:
+        raise ValueError("segments must contain at least one (lower, upper) pair")
+
+    segment_min = min(seg[0] for seg in segments_tuple)
+    segment_max = max(seg[1] for seg in segments_tuple)
+    if segment_max <= segment_min:
+        raise ValueError(
+            "Invalid segments: upper bound must be greater than lower bound"
+        )
+
+    y_grid = np.linspace(segment_min, segment_max, grid_size)
+
+    per_sample_rows: list[pd.DataFrame] = []
+    theta_matrix: list[np.ndarray] = []
+
+    for sample_id, group in df_long.groupby(group_col):
+        subset = group[[t_col, temp_col, y_col]].dropna()
+        if subset.empty:
+            continue
+        subset = subset.sort_values(t_col)
+        subset = subset.loc[~subset[t_col].duplicated(keep="first")]
+
+        if len(subset) < 2:
+            continue
+
+        time = subset[t_col].to_numpy(dtype=float)
+        temp = subset[temp_col].to_numpy(dtype=float) + 273.15
+        y_values = subset[y_col].to_numpy(dtype=float)
+
+        if np.any(np.diff(time) <= 0):
+            order = np.argsort(time)
+            time = time[order]
+            temp = temp[order]
+            y_values = y_values[order]
+            mask = np.concatenate(([True], np.diff(time) > 0))
+            time = time[mask]
+            temp = temp[mask]
+            y_values = y_values[mask]
+            if time.size < 2:
+                continue
+
+        integrand = np.exp(-(activation_energy * 1000.0) / (R_GAS_CONSTANT * temp))
+        theta = cumulative_trapezoid(integrand, time, initial=0.0)
+        theta_norm = _normalise_theta(theta, normalize_theta)
+
+        order_y = np.argsort(y_values)
+        y_sorted = y_values[order_y]
+        theta_sorted = theta_norm[order_y]
+        y_unique, unique_idx = np.unique(y_sorted, return_index=True)
+        theta_unique = theta_sorted[unique_idx]
+
+        if y_unique[0] > y_grid[0] or y_unique[-1] < y_grid[-1]:
+            continue
+
+        theta_interp = np.interp(y_grid, y_unique, theta_unique)
+        theta_matrix.append(theta_interp)
+
+        per_sample_rows.append(
+            pd.DataFrame(
+                {
+                    group_col: sample_id,
+                    "densification": y_grid,
+                    "theta": theta_interp,
+                }
+            )
+        )
+
+    if len(theta_matrix) < 2:
+        raise ValueError("At least two samples are required to build the MSC")
+
+    theta_stack = np.vstack(theta_matrix)
+    theta_mean = theta_stack.mean(axis=0)
+    theta_std = theta_stack.std(axis=0, ddof=0)
+    errors = (theta_stack - theta_mean) ** 2
+    mse_global = float(errors.mean())
+
+    segment_metrics: Dict[Tuple[float, float], float] = {}
+    weighted_sum = 0.0
+    total_weight = 0.0
+    for lower, upper in segments_tuple:
+        mask = (y_grid >= lower) & (y_grid <= upper)
+        if not np.any(mask):
+            segment_metrics[(lower, upper)] = float("nan")
+            continue
+        mse_value = float(errors[:, mask].mean())
+        segment_metrics[(lower, upper)] = mse_value
+        if np.isfinite(mse_value):
+            weight = upper - lower
+            weighted_sum += weight * mse_value
+            total_weight += weight
+
+    mse_segmented = weighted_sum / total_weight if total_weight > 0 else float("nan")
+
+    curve_df = pd.DataFrame(
+        {
+            "densification": y_grid,
+            "theta_mean": theta_mean,
+            "theta_std": theta_std,
+        }
+    )
+    per_sample_df = pd.concat(per_sample_rows, ignore_index=True)
+
+    return MasterCurveResult(
+        activation_energy=float(activation_energy),
+        curve=curve_df,
+        per_sample=per_sample_df,
+        mse_global=mse_global,
+        mse_segmented=mse_segmented,
+        segment_mse=segment_metrics,
+        normalize_theta=normalize_theta,
+        segments=segments_tuple,
+    )
+
+
+def score_activation_energies(
+    df_long: pd.DataFrame,
+    ea_kj_list: Iterable[float],
+    *,
+    metric: Literal["global", "segmented"] = "segmented",
+    **kwargs,
+) -> tuple[pd.DataFrame, MasterCurveResult, list[MasterCurveResult]]:
+    """Evaluate multiple activation energies and return collapse metrics."""
+
+    ea_values = list(ea_kj_list)
+    if not ea_values:
+        raise ValueError("ea_kj_list must contain at least one activation energy")
+
+    if metric not in {"global", "segmented"}:
+        raise ValueError("metric must be 'global' or 'segmented'")
+
+    results: list[MasterCurveResult] = []
+    rows: list[dict[str, float]] = []
+
+    for ea in ea_values:
+        result = build_master_curve(df_long, ea, **kwargs)
+        results.append(result)
+
+        row: dict[str, float] = {
+            "Ea_kJ_mol": float(ea),
+            "mse_global": result.mse_global,
+            "mse_segmented": result.mse_segmented,
+        }
+        for (lower, upper), value in result.segment_mse.items():
+            key = f"mse_{lower:.2f}_{upper:.2f}"
+            row[key] = value
+        rows.append(row)
+
+    summary = pd.DataFrame(rows).sort_values("Ea_kJ_mol").reset_index(drop=True)
+
+    metric_key = "mse_segmented" if metric == "segmented" else "mse_global"
+    best_result = None
+    best_value = float("inf")
+    for result in results:
+        value = getattr(result, metric_key)
+        if np.isnan(value):
+            continue
+        if value < best_value:
+            best_value = value
+            best_result = result
+
+    if best_result is None:
+        raise ValueError("No valid MSC could be computed for the provided Ea values")
+
+    return summary, best_result, results
+
+
+__all__ = [
+    "MasterCurveResult",
+    "OgumLite",
+    "R_GAS_CONSTANT",
+    "build_master_curve",
+    "score_activation_energies",
+]

--- a/ogum-ml-lite/tests/test_features.py
+++ b/ogum-ml-lite/tests/test_features.py
@@ -1,0 +1,75 @@
+"""Unit tests for feature engineering helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from ogum_lite.features import (
+    aggregate_timeseries,
+    build_feature_table,
+    finite_diff,
+    theta_features,
+)
+
+
+def synthetic_long_dataframe() -> pd.DataFrame:
+    time = np.linspace(0, 400, 81)
+    frames = []
+    for idx, temp_shift in enumerate([0.0, 5.0]):
+        rho = 1 - np.exp(-(time + idx * 15) / 140)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "sample_id": f"S{idx}",
+                    "time_s": time,
+                    "temp_C": 25 + 2.5 * time + temp_shift,
+                    "rho_rel": rho,
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_finite_diff_linear_profile() -> None:
+    x = np.linspace(0, 10, 6)
+    y = 3 * x - 5
+    derivative = finite_diff(y, x)
+    assert np.allclose(derivative, 3.0)
+
+
+def test_aggregate_timeseries_basic_metrics() -> None:
+    df = synthetic_long_dataframe()
+    aggregated = aggregate_timeseries(df)
+
+    assert set(aggregated.columns) == {
+        "sample_id",
+        "heating_rate_med_C_per_s",
+        "T_max_C",
+        "y_final",
+        "t_to_90pct_s",
+        "dy_dt_max",
+        "T_at_dy_dt_max_C",
+    }
+    assert len(aggregated) == 2
+    assert (aggregated["heating_rate_med_C_per_s"] > 0).all()
+    assert np.isfinite(aggregated["t_to_90pct_s"]).all()
+    assert (aggregated["T_max_C"] > 25).all()
+
+
+def test_theta_features_and_feature_table() -> None:
+    df = synthetic_long_dataframe()
+    thetas = theta_features(df, [200.0, 350.0])
+
+    assert {
+        "sample_id",
+        "theta_Ea_200kJ",
+        "theta_Ea_350kJ",
+    } <= set(thetas.columns)
+
+    for _, row in thetas.iterrows():
+        assert row["theta_Ea_200kJ"] > row["theta_Ea_350kJ"]
+
+    features_df = build_feature_table(df, [200.0, 350.0])
+    assert "theta_Ea_200kJ" in features_df.columns
+    assert "heating_rate_med_C_per_s" in features_df.columns
+    assert len(features_df) == 2

--- a/ogum-ml-lite/tests/test_msc.py
+++ b/ogum-ml-lite/tests/test_msc.py
@@ -1,0 +1,64 @@
+"""Tests for Master Sintering Curve utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from ogum_lite.theta_msc import build_master_curve, score_activation_energies
+
+
+def synthetic_runs(n_samples: int = 3) -> pd.DataFrame:
+    time = np.linspace(0, 600, 121)
+    frames = []
+    for idx in range(n_samples):
+        rho = 1 - np.exp(-(time + idx * 20) / 180)
+        temp = 25 + 3.5 * time + idx * 4
+        frames.append(
+            pd.DataFrame(
+                {
+                    "sample_id": f"S{idx}",
+                    "time_s": time,
+                    "temp_C": temp,
+                    "rho_rel": rho,
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_build_master_curve_segmented_metric_bounded() -> None:
+    df = synthetic_runs()
+    result = build_master_curve(df, 220.0)
+
+    assert {"densification", "theta_mean", "theta_std"} <= set(result.curve.columns)
+    assert result.mse_segmented <= 1.5 * result.mse_global
+
+
+def test_build_master_curve_requires_multiple_samples() -> None:
+    df = synthetic_runs(1)
+    with pytest.raises(ValueError, match="At least two samples"):
+        build_master_curve(df, 200.0)
+
+
+def test_score_activation_energies_returns_best_result() -> None:
+    df = synthetic_runs()
+    summary, best_result, results = score_activation_energies(
+        df,
+        [180.0, 200.0, 240.0],
+        metric="global",
+    )
+
+    assert len(results) == 3
+    assert not summary.empty
+    assert best_result.activation_energy in summary["Ea_kJ_mol"].values
+
+    raw_result = build_master_curve(
+        df,
+        best_result.activation_energy,
+        normalize_theta=None,
+    )
+    assert np.allclose(
+        raw_result.curve["densification"],
+        best_result.curve["densification"],
+    )

--- a/ogum-ml-lite/tests/test_smoke.py
+++ b/ogum-ml-lite/tests/test_smoke.py
@@ -14,8 +14,8 @@ def synthetic_dataset() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "time_s": time,
-            "temperature_C": temperature,
-            "densification": densification,
+            "temp_C": temperature,
+            "rho_rel": densification,
             "datatype": "heating",
         }
     )
@@ -32,7 +32,7 @@ def test_theta_and_msc_end_to_end(tmp_path) -> None:
 
     msc_df = ogum.build_msc(200)
     assert len(msc_df) == len(df)
-    assert np.isclose(msc_df["densification"].iloc[-1], df["densification"].iloc[-1])
+    assert np.isclose(msc_df["densification"].iloc[-1], df["rho_rel"].iloc[-1])
 
     msc_path = tmp_path / "msc.csv"
     msc_df.to_csv(msc_path, index=False)


### PR DESCRIPTION
## Summary
- implement per-sample feature engineering helpers with θ(Ea) aggregation
- add segmented MSC collapse metrics, selection helpers and richer CLI/UI flows
- expand documentation, notebook example, licensing and automated test coverage

## Testing
- `pip install -e .[dev]`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d58e81b4008327ae447f8c2ca16a2e