### PR TITLE
feat: add Arrhenius pipeline and stage-aware features

### DIFF
--- a/ogum-ml-lite/environment.yml
+++ b/ogum-ml-lite/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - matplotlib
   - joblib
   - gradio
+  - openpyxl
+  - xlrd
   - ruff
   - black
   - pytest

--- a/ogum-ml-lite/notebooks/ogum_ml_derivatives_demo.ipynb
+++ b/ogum-ml-lite/notebooks/ogum_ml_derivatives_demo.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ogum ML Derivatives & Arrhenius Demo\n",
+    "\n",
+    "This notebook showcases the new preprocessing pipeline for Ogum ML Lite.\n",
+    "We generate a synthetic dataset, compute derivatives, evaluate Arrhenius\n",
+    "activation energies and assemble the stage-aware feature store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from ogum_lite.io_mapping import ColumnMap, apply_mapping\n",
+    "from ogum_lite.preprocess import derive_all\n",
+    "from ogum_lite.arrhenius import arrhenius_feature_table\n",
+    "from ogum_lite.features import build_feature_store\n",
+    "\n",
+    "# Synthetic raw spreadsheet mimicking Ogum 6.4 aliases\n",
+    "time = np.linspace(0, 1800, 181)\n",
+    "raw_df = pd.DataFrame(\n",
+    "    {\n",
+    "        'Sample': ['Demo'] * time.size,\n",
+    "        'tempo_min': time / 60,\n",
+    "        'temp_K': 873.15 + 0.12 * time,\n",
+    "        'densidade_relativa': 0.4 + 0.6 * (1 - np.exp(-time / 600)),\n",
+    "        'composition': 'Fe-2Cu',\n",
+    "        'technique': 'Flash',\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "mapping = ColumnMap(\n",
+    "    sample_id='Sample',\n",
+    "    time_col='tempo_min',\n",
+    "    temp_col='temp_K',\n",
+    "    y_col='densidade_relativa',\n",
+    "    composition='composition',\n",
+    "    technique='technique',\n",
+    "    time_unit='min',\n",
+    "    temp_unit='K',\n",
+    ")\n",
+    "canonical = apply_mapping(raw_df, mapping)\n",
+    "canonical.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "derived = derive_all(canonical, smooth='savgol', window=9, poly=3)\n",
+    "arrhenius = arrhenius_feature_table(derived)\n",
+    "feature_store = build_feature_store(derived, theta_ea_kj=[200.0, 250.0])\n",
+    "\n",
+    "display(arrhenius)\n",
+    "display(feature_store.head())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ogum-ml-lite/ogum_lite/__init__.py
+++ b/ogum-ml-lite/ogum_lite/__init__.py
@@ -2,7 +2,10 @@
 
 from .features import (
     aggregate_timeseries,
+    arrhenius_feature_table,
+    build_feature_store,
     build_feature_table,
+    build_stage_feature_tables,
     finite_diff,
     theta_features,
 )
@@ -25,7 +28,10 @@ __all__ = [
     "OgumLite",
     "R_GAS_CONSTANT",
     "aggregate_timeseries",
+    "arrhenius_feature_table",
     "build_feature_table",
+    "build_feature_store",
+    "build_stage_feature_tables",
     "build_master_curve",
     "finite_diff",
     "kmeans_explore",

--- a/ogum-ml-lite/ogum_lite/arrhenius.py
+++ b/ogum-ml-lite/ogum_lite/arrhenius.py
@@ -1,0 +1,191 @@
+"""Arrhenius regression helpers for sintering kinetics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Literal
+
+import numpy as np
+import pandas as pd
+from scipy.stats import linregress
+
+from .stages import DEFAULT_STAGES, split_by_stages
+
+R_GAS_CONSTANT = 8.314462618  # J/(mol*K)
+
+
+@dataclass
+class ArrheniusResult:
+    """Container for Arrhenius linear regressions."""
+
+    Ea_J_mol: float
+    slope: float
+    intercept: float
+    rvalue: float
+    n_points: int
+    method: Literal["global", "stage", "sliding"]
+    meta: dict[str, Any]
+
+
+def arrhenius_lnT_dy_dt_vs_invT(
+    df: pd.DataFrame,
+    *,
+    T_col: str = "temp_C",
+    dy_dt_col: str = "dy_dt",
+) -> pd.DataFrame:
+    """Prepare dataframe with ``ln(T*dy/dt)`` versus ``1/T`` columns."""
+
+    required = {T_col, dy_dt_col}
+    missing = required - set(df.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing required columns: {missing_cols}")
+
+    prepared = df.copy()
+    T_K = prepared[T_col].astype(float) + 273.15
+    dy_dt = prepared[dy_dt_col].astype(float)
+    dy_dt_clip = np.clip(dy_dt, 1e-12, None)
+
+    prepared["T_K"] = T_K
+    prepared["invT_K"] = 1.0 / T_K
+    prepared["ln_T_dy_dt"] = np.log(T_K * dy_dt_clip)
+    return prepared
+
+
+def _linear_fit(df: pd.DataFrame) -> tuple[float, float, float, int]:
+    subset = df[["invT_K", "ln_T_dy_dt"]].dropna()
+    if subset.shape[0] < 3:
+        raise ValueError("At least three valid points are required for Arrhenius fit")
+    result = linregress(subset["invT_K"], subset["ln_T_dy_dt"])
+    return result.slope, result.intercept, result.rvalue, subset.shape[0]
+
+
+def _ensure_prepared(
+    df: pd.DataFrame, *, T_col: str = "temp_C", dy_dt_col: str = "dy_dt"
+) -> pd.DataFrame:
+    if {"invT_K", "ln_T_dy_dt"}.issubset(df.columns):
+        return df
+    return arrhenius_lnT_dy_dt_vs_invT(df, T_col=T_col, dy_dt_col=dy_dt_col)
+
+
+def fit_arrhenius_global(
+    df: pd.DataFrame,
+    *,
+    T_col: str = "temp_C",
+    dy_dt_col: str = "dy_dt",
+) -> ArrheniusResult:
+    """Fit Arrhenius regression using all available samples."""
+
+    prepared = _ensure_prepared(df, T_col=T_col, dy_dt_col=dy_dt_col)
+    slope, intercept, rvalue, n_points = _linear_fit(prepared)
+    Ea = -slope * R_GAS_CONSTANT
+    return ArrheniusResult(
+        Ea_J_mol=float(Ea),
+        slope=float(slope),
+        intercept=float(intercept),
+        rvalue=float(rvalue),
+        n_points=int(n_points),
+        method="global",
+        meta={},
+    )
+
+
+def fit_arrhenius_by_stages(
+    df: pd.DataFrame,
+    *,
+    stages: Iterable[tuple[float, float]] = DEFAULT_STAGES,
+    y_col: str = "y",
+    group_col: str = "sample_id",
+) -> list[ArrheniusResult]:
+    """Fit Arrhenius regressions for each densification stage."""
+
+    prepared = _ensure_prepared(df)
+    stage_frames = split_by_stages(
+        prepared, y_col=y_col, group_col=group_col, stages=stages
+    )
+
+    results: list[ArrheniusResult] = []
+    for idx, ((lower, upper), label) in enumerate(zip(stages, stage_frames)):
+        frame = stage_frames[label]
+        if frame.empty:
+            continue
+        slope, intercept, rvalue, n_points = _linear_fit(frame)
+        Ea = -slope * R_GAS_CONSTANT
+        results.append(
+            ArrheniusResult(
+                Ea_J_mol=float(Ea),
+                slope=float(slope),
+                intercept=float(intercept),
+                rvalue=float(rvalue),
+                n_points=int(n_points),
+                method="stage",
+                meta={"stage": label, "lower": float(lower), "upper": float(upper)},
+            )
+        )
+    return results
+
+
+def fit_arrhenius_sliding(
+    df: pd.DataFrame,
+    *,
+    window_pts: int = 25,
+    step: int = 5,
+    t_col: str = "time_s",
+    group_col: str = "sample_id",
+) -> list[ArrheniusResult]:
+    """Fit Arrhenius regressions over sliding windows along the time axis."""
+
+    if window_pts < 5:
+        raise ValueError("window_pts must be at least 5")
+    if step < 1:
+        raise ValueError("step must be positive")
+
+    prepared = _ensure_prepared(df)
+    results: list[ArrheniusResult] = []
+
+    grouped = (
+        prepared.groupby(group_col)
+        if group_col in prepared.columns
+        else [(None, prepared)]
+    )
+    for sample_id, group in grouped:
+        subset = group.sort_values(t_col)
+        if subset.shape[0] < window_pts:
+            continue
+        values = subset[[t_col, "invT_K", "ln_T_dy_dt"]].dropna()
+        if values.shape[0] < window_pts:
+            continue
+
+        for start in range(0, values.shape[0] - window_pts + 1, step):
+            window_df = values.iloc[start : start + window_pts]
+            try:
+                slope, intercept, rvalue, n_points = _linear_fit(window_df)
+            except ValueError:
+                continue
+            Ea = -slope * R_GAS_CONSTANT
+            results.append(
+                ArrheniusResult(
+                    Ea_J_mol=float(Ea),
+                    slope=float(slope),
+                    intercept=float(intercept),
+                    rvalue=float(rvalue),
+                    n_points=int(n_points),
+                    method="sliding",
+                    meta={
+                        "sample_id": sample_id,
+                        "t_start": float(window_df[t_col].iloc[0]),
+                        "t_end": float(window_df[t_col].iloc[-1]),
+                    },
+                )
+            )
+    return results
+
+
+__all__ = [
+    "ArrheniusResult",
+    "arrhenius_lnT_dy_dt_vs_invT",
+    "fit_arrhenius_global",
+    "fit_arrhenius_by_stages",
+    "fit_arrhenius_sliding",
+    "R_GAS_CONSTANT",
+]

--- a/ogum-ml-lite/ogum_lite/io_mapping.py
+++ b/ogum-ml-lite/ogum_lite/io_mapping.py
@@ -1,0 +1,212 @@
+"""I/O helpers to map heterogeneous spreadsheets into Ogum's canonical schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Literal
+
+import pandas as pd
+
+TimeUnit = Literal["s", "min"]
+TemperatureUnit = Literal["C", "K"]
+
+
+@dataclass(frozen=True)
+class ColumnMap:
+    """Mapping between heterogeneous column names and Ogum's canonical schema."""
+
+    sample_id: str
+    time_col: str
+    temp_col: str
+    y_col: str
+    composition: str
+    technique: str
+    time_unit: TimeUnit = "s"
+    temp_unit: TemperatureUnit = "C"
+
+
+ALIASES: Dict[str, Iterable[str]] = {
+    "sample_id": ["sample_id", "id", "sample", "amostra", "run_id"],
+    "time": [
+        "time_s",
+        "time",
+        "tempo",
+        "t_s",
+        "time_min",
+        "t",
+        "tempo_min",
+    ],
+    "temperature": [
+        "temp_c",
+        "temperature",
+        "temp",
+        "t_c",
+        "temp_k",
+        "temperature_c",
+        "temperature_k",
+        "t_k",
+    ],
+    "response": [
+        "rho_rel",
+        "densification",
+        "densidade_relativa",
+        "shrinkage_rel",
+        "y",
+        "response",
+    ],
+    "composition": ["composition", "alloy", "material", "comp", "liga"],
+    "technique": ["technique", "process", "route", "tecnica", "method"],
+}
+
+
+TECHNIQUE_CHOICES = [
+    "Conventional",
+    "UHS",
+    "Flash",
+    "SPS",
+    "Two-Step",
+    "Cold",
+    "HeatingOnly",
+]
+
+
+def _normalise(name: str) -> str:
+    return (
+        name.strip()
+        .lower()
+        .replace(" ", "")
+        .replace("-", "")
+        .replace("_", "")
+        .replace("/", "")
+    )
+
+
+def read_table(path: str | Path) -> pd.DataFrame:
+    """Read CSV/XLS/XLSX files using pandas based on the file extension."""
+
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    if suffix in {".xls", ".xlsx"}:
+        return pd.read_excel(path)
+    raise ValueError(f"Unsupported file extension: {suffix}")
+
+
+def _match_column(df: pd.DataFrame, key: str) -> str:
+    aliases = ALIASES.get(key, [])
+    norm_aliases = {_normalise(alias): alias for alias in aliases}
+    for column in df.columns:
+        norm = _normalise(str(column))
+        if norm in norm_aliases:
+            return str(column)
+    raise KeyError(f"Unable to infer column for '{key}'")
+
+
+def _detect_time_unit(column_name: str) -> TimeUnit:
+    lowered = column_name.lower()
+    if "min" in lowered and not lowered.endswith("s"):
+        return "min"
+    if lowered.endswith("_min") or lowered.endswith("min"):
+        return "min"
+    return "s"
+
+
+def _detect_temperature_unit(column_name: str) -> TemperatureUnit:
+    lowered = column_name.lower()
+    if lowered.endswith("k") or "kelvin" in lowered:
+        return "K"
+    if lowered.endswith("_k"):
+        return "K"
+    return "C"
+
+
+def infer_mapping(df: pd.DataFrame) -> ColumnMap:
+    """Infer :class:`ColumnMap` for a dataframe based on column aliases."""
+
+    sample_id = _match_column(df, "sample_id")
+    time_col = _match_column(df, "time")
+    temp_col = _match_column(df, "temperature")
+    y_col = _match_column(df, "response")
+    composition = _match_column(df, "composition")
+    technique = _match_column(df, "technique")
+
+    time_unit = _detect_time_unit(time_col)
+    temp_unit = _detect_temperature_unit(temp_col)
+
+    return ColumnMap(
+        sample_id=sample_id,
+        time_col=time_col,
+        temp_col=temp_col,
+        y_col=y_col,
+        composition=composition,
+        technique=technique,
+        time_unit=time_unit,
+        temp_unit=temp_unit,
+    )
+
+
+def apply_mapping(df: pd.DataFrame, cmap: ColumnMap) -> pd.DataFrame:
+    """Project ``df`` into Ogum's canonical schema using ``cmap``."""
+
+    required_columns = {
+        cmap.sample_id,
+        cmap.time_col,
+        cmap.temp_col,
+        cmap.y_col,
+    }
+    missing = required_columns - set(df.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing columns required by mapping: {missing_cols}")
+
+    dataframe = df.copy()
+
+    time_series = dataframe[cmap.time_col].astype(float)
+    if cmap.time_unit == "min":
+        time_series = time_series * 60.0
+
+    temp_series = dataframe[cmap.temp_col].astype(float)
+    if cmap.temp_unit == "K":
+        temp_series = temp_series - 273.15
+
+    y_series = dataframe[cmap.y_col].astype(float)
+
+    result = pd.DataFrame(
+        {
+            "sample_id": dataframe[cmap.sample_id].astype(str),
+            "time_s": time_series,
+            "temp_C": temp_series,
+            "y": y_series,
+        }
+    )
+
+    if cmap.composition in dataframe.columns:
+        result["composition"] = dataframe[cmap.composition].astype(str)
+    else:
+        result["composition"] = cmap.composition
+
+    if cmap.technique in dataframe.columns:
+        tech_values = dataframe[cmap.technique].fillna(TECHNIQUE_CHOICES[0]).astype(str)
+    else:
+        tech_values = pd.Series(cmap.technique, index=result.index, dtype=str)
+    if not tech_values.isin(TECHNIQUE_CHOICES).all():
+        invalid = sorted(set(tech_values) - set(TECHNIQUE_CHOICES))
+        raise ValueError(
+            "Invalid technique detected. Expected one of "
+            f"{', '.join(TECHNIQUE_CHOICES)}; got {invalid}"
+        )
+    result["technique"] = tech_values
+
+    return result
+
+
+__all__ = [
+    "ColumnMap",
+    "ALIASES",
+    "TECHNIQUE_CHOICES",
+    "read_table",
+    "infer_mapping",
+    "apply_mapping",
+]

--- a/ogum-ml-lite/ogum_lite/preprocess.py
+++ b/ogum-ml-lite/ogum_lite/preprocess.py
@@ -1,0 +1,146 @@
+"""Pre-processing utilities: smoothing and numerical derivatives."""
+
+from __future__ import annotations
+
+from typing import Iterable, Literal
+
+import numpy as np
+import pandas as pd
+from scipy.signal import savgol_filter
+
+SmoothMethod = Literal["savgol", "moving", "none"]
+
+
+def smooth_series(
+    values: Iterable[float],
+    *,
+    method: SmoothMethod = "savgol",
+    window: int = 11,
+    poly: int = 3,
+    moving_k: int = 5,
+) -> np.ndarray:
+    """Smooth 1D series using Savitzky–Golay or moving average filters."""
+
+    array = np.asarray(values, dtype=float)
+    if array.size == 0:
+        return array
+
+    if method == "none":
+        return array.copy()
+
+    if method == "savgol":
+        win = max(3, int(window))
+        if win % 2 == 0:
+            win += 1
+        win = min(win, array.size if array.size % 2 == 1 else array.size - 1)
+        if win < 3:
+            return array.copy()
+        if poly >= win:
+            poly = win - 1
+        return savgol_filter(
+            array, window_length=win, polyorder=max(poly, 1), mode="interp"
+        )
+
+    if method == "moving":
+        k = max(1, int(moving_k))
+        window_arr = np.ones(k) / k
+        return np.convolve(array, window_arr, mode="same")
+
+    raise ValueError("Unsupported smoothing method")
+
+
+def finite_diff(y: Iterable[float], x: Iterable[float]) -> np.ndarray:
+    """Compute first-order derivatives using centred finite differences."""
+
+    y = np.asarray(y, dtype=float)
+    x = np.asarray(x, dtype=float)
+
+    if y.shape != x.shape:
+        raise ValueError("`y` and `x` must share the same shape")
+    if y.size < 2:
+        raise ValueError("At least two samples are required to estimate the derivative")
+    if np.any(np.diff(x) <= 0):
+        raise ValueError("Array `x` must be strictly increasing")
+
+    derivative = np.empty_like(y, dtype=float)
+    derivative[1:-1] = (y[2:] - y[:-2]) / (x[2:] - x[:-2])
+    derivative[0] = (y[1] - y[0]) / (x[1] - x[0])
+    derivative[-1] = (y[-1] - y[-2]) / (x[-1] - x[-2])
+    return derivative
+
+
+def derive_all(
+    df: pd.DataFrame,
+    *,
+    t_col: str = "time_s",
+    T_col: str = "temp_C",
+    y_col: str = "y",
+    smooth: SmoothMethod = "savgol",
+    window: int = 11,
+    poly: int = 3,
+    moving_k: int = 5,
+) -> pd.DataFrame:
+    """Compute time and temperature derivatives used in Arrhenius analyses."""
+
+    required = {t_col, T_col, y_col}
+    missing = required - set(df.columns)
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise KeyError(f"Missing required columns: {missing_cols}")
+
+    result = df.copy()
+    group_col = "sample_id" if "sample_id" in result.columns else None
+
+    groups: Iterable[tuple[str | int | None, pd.DataFrame]]
+    if group_col:
+        groups = ((name, group) for name, group in result.groupby(group_col))
+    else:
+        groups = [(None, result)]
+
+    for _, group in groups:
+        subset = group[[t_col, T_col, y_col]].dropna()
+        if subset.empty:
+            continue
+        subset = subset.sort_values(t_col)
+        subset = subset.loc[~subset[t_col].duplicated(keep="first")]
+
+        index = subset.index.to_numpy()
+        time = subset[t_col].to_numpy(dtype=float)
+        temp = subset[T_col].to_numpy(dtype=float)
+        y_values = subset[y_col].to_numpy(dtype=float)
+
+        if time.size < 2:
+            result.loc[index, "dy_dt"] = np.nan
+            result.loc[index, "dT_dt"] = np.nan
+            result.loc[index, "dp_dT"] = np.nan
+            result.loc[index, "T_times_dy_dt"] = np.nan
+            result.loc[index, "T_times_dp_dT_times_dT_dt"] = np.nan
+            continue
+
+        y_smooth = smooth_series(
+            y_values, method=smooth, window=window, poly=poly, moving_k=moving_k
+        )
+
+        try:
+            dy_dt = finite_diff(y_smooth, time)
+            dT_dt = finite_diff(temp, time)
+        except ValueError:
+            dy_dt = np.full_like(time, np.nan, dtype=float)
+            dT_dt = np.full_like(time, np.nan, dtype=float)
+
+        dp_dT = dy_dt / (dT_dt + 1e-12)
+        T_K = temp + 273.15
+        T_times_dy_dt = T_K * dy_dt
+        T_times_dp_dT_times_dT_dt = T_K * dp_dT * dT_dt
+
+        result.loc[index, "y_smooth"] = y_smooth
+        result.loc[index, "dy_dt"] = dy_dt
+        result.loc[index, "dT_dt"] = dT_dt
+        result.loc[index, "dp_dT"] = dp_dT
+        result.loc[index, "T_times_dy_dt"] = T_times_dy_dt
+        result.loc[index, "T_times_dp_dT_times_dT_dt"] = T_times_dp_dT_times_dT_dt
+
+    return result
+
+
+__all__ = ["SmoothMethod", "smooth_series", "finite_diff", "derive_all"]

--- a/ogum-ml-lite/ogum_lite/stages.py
+++ b/ogum-ml-lite/ogum_lite/stages.py
@@ -1,0 +1,69 @@
+"""Helpers to segment densification curves into canonical sintering stages."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_STAGES: tuple[tuple[float, float], ...] = ((0.55, 0.70), (0.70, 0.90))
+
+
+def stage_masks(
+    y: np.ndarray, stages: Iterable[tuple[float, float]]
+) -> list[np.ndarray]:
+    """Build boolean masks selecting samples belonging to each stage."""
+
+    y = np.asarray(y, dtype=float)
+    masks: list[np.ndarray] = []
+    for lower, upper in stages:
+        mask = (y >= float(lower)) & (y < float(upper))
+        masks.append(mask)
+    return masks
+
+
+def split_by_stages(
+    df: pd.DataFrame,
+    *,
+    y_col: str = "y",
+    group_col: str = "sample_id",
+    stages: Iterable[tuple[float, float]] = DEFAULT_STAGES,
+) -> dict[str, pd.DataFrame]:
+    """Segment a long-format dataframe according to densification stages."""
+
+    if y_col not in df.columns:
+        raise KeyError(f"Column '{y_col}' not present in dataframe")
+
+    grouped = df.groupby(group_col) if group_col in df.columns else [(None, df)]
+    stage_dict: dict[str, list[pd.DataFrame]] = {
+        f"stage_{idx+1}": [] for idx, _ in enumerate(stages)
+    }
+
+    for _, group in grouped:
+        if group.empty:
+            continue
+        y_values = group[y_col].to_numpy(dtype=float)
+        masks = stage_masks(y_values, stages)
+        for idx, mask in enumerate(masks):
+            if not np.any(mask):
+                continue
+            stage_df = group.loc[mask].copy()
+            stage_df["stage_label"] = f"stage_{idx+1}"
+            stage_dict[f"stage_{idx+1}"].append(stage_df)
+
+    columns = list(df.columns)
+    if "stage_label" not in columns:
+        columns = [*columns, "stage_label"]
+
+    return {
+        label: (
+            pd.concat(parts, ignore_index=True)
+            if parts
+            else pd.DataFrame(columns=columns)
+        )
+        for label, parts in stage_dict.items()
+    }
+
+
+__all__ = ["DEFAULT_STAGES", "stage_masks", "split_by_stages"]

--- a/ogum-ml-lite/ogum_lite/theta_msc.py
+++ b/ogum-ml-lite/ogum_lite/theta_msc.py
@@ -18,6 +18,8 @@ import numpy as np
 import pandas as pd
 from scipy.integrate import cumulative_trapezoid
 
+from .stages import DEFAULT_STAGES
+
 R_GAS_CONSTANT = 8.314462618  # J/(mol*K)
 
 
@@ -311,7 +313,7 @@ def build_master_curve(
     temp_col: str = "temp_C",
     y_col: str = "rho_rel",
     normalize_theta: Literal["minmax", None] = "minmax",
-    segments: Sequence[Tuple[float, float]] = ((0.55, 0.70), (0.70, 0.90)),
+    segments: Sequence[Tuple[float, float]] = DEFAULT_STAGES,
     grid_size: int = 200,
 ) -> MasterCurveResult:
     """Collapse multiple runs into a MSC and compute error metrics.

--- a/ogum-ml-lite/pyproject.toml
+++ b/ogum-ml-lite/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "matplotlib",
     "joblib",
     "gradio",
+    "openpyxl",
+    "xlrd",
 ]
 
 [project.optional-dependencies]

--- a/ogum-ml-lite/tests/test_arrhenius.py
+++ b/ogum-ml-lite/tests/test_arrhenius.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from ogum_lite.arrhenius import (
+    R_GAS_CONSTANT,
+    arrhenius_lnT_dy_dt_vs_invT,
+    fit_arrhenius_by_stages,
+    fit_arrhenius_global,
+    fit_arrhenius_sliding,
+)
+from ogum_lite.stages import DEFAULT_STAGES
+
+
+def synthetic_arrhenius_dataset() -> pd.DataFrame:
+    time = np.linspace(0.0, 1500.0, 250)
+    temp_C = 25.0 + 0.15 * time
+    T_K = temp_C + 273.15
+    Ea = 85_000.0  # J/mol
+    A = 2.0e7
+    dy_dt = A * np.exp(-Ea / (R_GAS_CONSTANT * T_K))
+    dt = time[1] - time[0]
+    y = np.cumsum(dy_dt) * dt
+    y = y / y.max() * 0.95
+
+    return pd.DataFrame(
+        {
+            "sample_id": "S1",
+            "time_s": time,
+            "temp_C": temp_C,
+            "y": y,
+            "dy_dt": dy_dt,
+        }
+    )
+
+
+def test_fit_arrhenius_global_recovers_activation_energy() -> None:
+    df = synthetic_arrhenius_dataset()
+    prepared = arrhenius_lnT_dy_dt_vs_invT(df)
+    result = fit_arrhenius_global(prepared)
+    assert result.Ea_J_mol == pytest.approx(85_000.0, rel=0.05)
+
+
+def test_fit_arrhenius_by_stages_produces_results() -> None:
+    df = synthetic_arrhenius_dataset()
+    prepared = arrhenius_lnT_dy_dt_vs_invT(df)
+    results = fit_arrhenius_by_stages(prepared, stages=DEFAULT_STAGES, y_col="y")
+    assert len(results) >= 1
+
+
+def test_fit_arrhenius_sliding_returns_windows() -> None:
+    df = synthetic_arrhenius_dataset()
+    prepared = arrhenius_lnT_dy_dt_vs_invT(df)
+    results = fit_arrhenius_sliding(prepared, window_pts=30, step=10)
+    assert results

--- a/ogum-ml-lite/tests/test_cli_integration.py
+++ b/ogum-ml-lite/tests/test_cli_integration.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from ogum_lite.cli import main
+
+
+def _run_cli(args: list[str]) -> str:
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        main(args)
+    return buffer.getvalue()
+
+
+def _make_raw_dataframe() -> pd.DataFrame:
+    time_min = np.linspace(0.0, 6.0, 48)
+    temp_K = 900.0 + 60.0 * (time_min / time_min.max()) + 30.0
+    densification = 0.50 + 0.45 * (time_min / time_min.max()) ** 1.2
+
+    first = pd.DataFrame(
+        {
+            "Sample": "A",
+            "tempo_min": time_min,
+            "Temp_K": temp_K,
+            "rho_rel": densification,
+            "composition": "Fe2O3",
+            "technique": "SPS",
+        }
+    )
+
+    second = pd.DataFrame(
+        {
+            "Sample": "B",
+            "tempo_min": time_min,
+            "Temp_K": temp_K + 20.0,
+            "rho_rel": densification * 0.98,
+            "composition": "Fe2O3",
+            "technique": "SPS",
+        }
+    )
+
+    combined = pd.concat([first, second], ignore_index=True)
+    return combined
+
+
+def test_cli_pipeline_end_to_end(tmp_path: Path) -> None:
+    raw_df = _make_raw_dataframe()
+    raw_path = tmp_path / "raw.csv"
+    raw_df.to_csv(raw_path, index=False)
+
+    mapping_path = tmp_path / "mapping.json"
+    _run_cli(["io", "map", "--input", str(raw_path), "--out", str(mapping_path)])
+    mapping_data = json.loads(mapping_path.read_text())
+    assert mapping_data["time_unit"] == "min"
+    assert mapping_data["temp_unit"] == "K"
+
+    derived_path = tmp_path / "derivatives.csv"
+    _run_cli(
+        [
+            "preprocess",
+            "derive",
+            "--input",
+            str(raw_path),
+            "--map",
+            str(mapping_path),
+            "--smooth",
+            "none",
+            "--out",
+            str(derived_path),
+        ]
+    )
+    derived_df = pd.read_csv(derived_path)
+    assert {"dy_dt", "dT_dt", "dp_dT"}.issubset(derived_df.columns)
+    assert np.all(np.isfinite(derived_df["time_s"]))
+
+    stages_arg = "0.55-0.70,0.70-0.90"
+    arrhenius_path = tmp_path / "arrhenius.csv"
+    _run_cli(
+        [
+            "arrhenius",
+            "fit",
+            "--input",
+            str(derived_path),
+            "--out",
+            str(arrhenius_path),
+            "--stages",
+            stages_arg,
+        ]
+    )
+    arrhenius_df = pd.read_csv(arrhenius_path)
+    assert "Ea_arr_global_kJ" in arrhenius_df.columns
+    assert arrhenius_df["Ea_arr_global_kJ"].notna().all()
+
+    features_path = tmp_path / "feature_store.csv"
+    _run_cli(
+        [
+            "features",
+            "build",
+            "--input",
+            str(derived_path),
+            "--output",
+            str(features_path),
+            "--stages",
+            stages_arg,
+            "--smooth",
+            "none",
+        ]
+    )
+    feature_store = pd.read_csv(features_path)
+    expected_columns = {
+        "heating_rate_med_C_per_s",
+        "heating_rate_med_C_per_s_s1",
+        "Ea_arr_global_kJ",
+        "Ea_arr_55_70_kJ",
+        "Ea_arr_70_90_kJ",
+    }
+    assert expected_columns.issubset(feature_store.columns)
+    assert feature_store["Ea_arr_global_kJ"].notna().all()

--- a/ogum-ml-lite/tests/test_features.py
+++ b/ogum-ml-lite/tests/test_features.py
@@ -6,10 +6,14 @@ import numpy as np
 import pandas as pd
 from ogum_lite.features import (
     aggregate_timeseries,
+    arrhenius_feature_table,
+    build_feature_store,
     build_feature_table,
+    build_stage_feature_tables,
     finite_diff,
     theta_features,
 )
+from ogum_lite.stages import DEFAULT_STAGES
 
 
 def synthetic_long_dataframe() -> pd.DataFrame:
@@ -41,7 +45,7 @@ def test_aggregate_timeseries_basic_metrics() -> None:
     df = synthetic_long_dataframe()
     aggregated = aggregate_timeseries(df)
 
-    assert set(aggregated.columns) == {
+    assert {
         "sample_id",
         "heating_rate_med_C_per_s",
         "T_max_C",
@@ -49,11 +53,50 @@ def test_aggregate_timeseries_basic_metrics() -> None:
         "t_to_90pct_s",
         "dy_dt_max",
         "T_at_dy_dt_max_C",
-    }
+        "dT_dt_max",
+        "t_at_dT_dt_max_s",
+    } <= set(aggregated.columns)
     assert len(aggregated) == 2
     assert (aggregated["heating_rate_med_C_per_s"] > 0).all()
     assert np.isfinite(aggregated["t_to_90pct_s"]).all()
     assert (aggregated["T_max_C"] > 25).all()
+
+
+def test_build_stage_feature_tables_produces_suffixes() -> None:
+    df = synthetic_long_dataframe().rename(columns={"rho_rel": "y"})
+    stage_tables = build_stage_feature_tables(df, stages=DEFAULT_STAGES)
+
+    assert set(stage_tables) == {"stage_1", "stage_2"}
+    for idx, table in enumerate(stage_tables.values(), start=1):
+        assert all(
+            column.endswith(f"_s{idx}") or column == "sample_id"
+            for column in table.columns
+        )
+
+
+def test_arrhenius_feature_table_contains_stage_columns() -> None:
+    df = synthetic_long_dataframe().rename(columns={"rho_rel": "y"})
+    arrhenius_df = arrhenius_feature_table(df, stages=DEFAULT_STAGES)
+
+    expected = {
+        "Ea_arr_global_kJ",
+        "rvalue_arr_global",
+        "Ea_arr_55_70_kJ",
+        "rvalue_arr_55_70",
+        "Ea_arr_70_90_kJ",
+        "rvalue_arr_70_90",
+    }
+    assert expected <= set(arrhenius_df.columns)
+
+
+def test_build_feature_store_stage_columns_present() -> None:
+    df = synthetic_long_dataframe().rename(columns={"rho_rel": "y"})
+    feature_store = build_feature_store(df, stages=DEFAULT_STAGES)
+
+    for idx in range(1, len(DEFAULT_STAGES) + 1):
+        suffix = f"_s{idx}"
+        assert any(column.endswith(suffix) for column in feature_store.columns)
+    assert "Ea_arr_global_kJ" in feature_store.columns
 
 
 def test_theta_features_and_feature_table() -> None:

--- a/ogum-ml-lite/tests/test_io_mapping.py
+++ b/ogum-ml-lite/tests/test_io_mapping.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from ogum_lite.io_mapping import (
+    TECHNIQUE_CHOICES,
+    apply_mapping,
+    infer_mapping,
+    read_table,
+)
+
+
+def test_infer_mapping_detects_units_and_aliases() -> None:
+    df = pd.DataFrame(
+        {
+            "Sample": ["A", "B"],
+            "tempo_min": [1.5, 2.0],
+            "temp_K": [973.15, 983.15],
+            "densidade_relativa": [0.5, 0.6],
+            "composition": ["Fe", "Fe"],
+            "technique": [TECHNIQUE_CHOICES[0], TECHNIQUE_CHOICES[0]],
+        }
+    )
+
+    mapping = infer_mapping(df)
+    assert mapping.sample_id.lower().startswith("sample")
+    assert mapping.time_unit == "min"
+    assert mapping.temp_unit == "K"
+
+    mapped = apply_mapping(df, mapping)
+    assert mapped["time_s"].iloc[0] == pytest.approx(90.0)
+    assert mapped["temp_C"].iloc[0] == pytest.approx(700.0)
+    assert "composition" in mapped.columns
+    assert set(mapped["technique"]) == {TECHNIQUE_CHOICES[0]}
+
+
+def test_read_table_supports_csv_and_excel(tmp_path) -> None:
+    pytest.importorskip("openpyxl")
+    dataframe = pd.DataFrame(
+        {
+            "sample_id": [1, 2],
+            "time_s": [0.0, 1.0],
+            "temp_C": [25.0, 30.0],
+        }
+    )
+
+    io_dir = tmp_path / "io"
+    io_dir.mkdir()
+    csv_path = io_dir / "data.csv"
+    dataframe.to_csv(csv_path, index=False)
+    loaded_csv = read_table(csv_path)
+    assert list(loaded_csv.columns) == list(dataframe.columns)
+
+    xlsx_path = io_dir / "data.xlsx"
+    dataframe.to_excel(xlsx_path, index=False)
+    loaded_xlsx = read_table(xlsx_path)
+    assert list(loaded_xlsx.columns) == list(dataframe.columns)

--- a/ogum-ml-lite/tests/test_preprocess.py
+++ b/ogum-ml-lite/tests/test_preprocess.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from ogum_lite.preprocess import derive_all, smooth_series
+
+
+def test_savgol_smoothing_preserves_linear_trend() -> None:
+    data = np.linspace(0, 10, 21)
+    smoothed = smooth_series(data, method="savgol", window=5, poly=2)
+    assert np.allclose(smoothed, data)
+
+
+def test_derive_all_linear_profiles() -> None:
+    time = np.linspace(0, 49, 50)
+    df = pd.DataFrame(
+        {
+            "sample_id": "S1",
+            "time_s": time,
+            "temp_C": 20.0 + 2.0 * time,
+            "y": 0.3 + 0.01 * time,
+        }
+    )
+
+    derived = derive_all(df, smooth="none")
+
+    assert np.allclose(derived["dT_dt"].dropna(), 2.0)
+    assert np.allclose(derived["dy_dt"].dropna(), 0.01)
+    assert np.allclose(derived["dp_dT"].dropna(), 0.01 / 2.0, atol=1e-6)
+    t_kelvin = derived["temp_C"] + 273.15
+    assert np.allclose(derived["T_times_dy_dt"].dropna(), t_kelvin.dropna() * 0.01)

--- a/ogum-ml-lite/tests/test_stages.py
+++ b/ogum-ml-lite/tests/test_stages.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from ogum_lite.stages import DEFAULT_STAGES, split_by_stages, stage_masks
+
+
+def test_stage_masks_split_ranges() -> None:
+    y = np.array([0.5, 0.6, 0.72, 0.88, 0.93])
+    masks = stage_masks(y, DEFAULT_STAGES)
+    assert len(masks) == len(DEFAULT_STAGES)
+    assert masks[0].sum() == 1  # only the 0.6 value
+    assert masks[1].sum() == 2
+
+
+def test_split_by_stages_preserves_labels() -> None:
+    df = pd.DataFrame(
+        {
+            "sample_id": ["A"] * 5 + ["B"] * 5,
+            "time_s": np.tile(np.arange(5.0), 2),
+            "y": np.concatenate([np.linspace(0.5, 0.95, 5), np.linspace(0.52, 0.9, 5)]),
+        }
+    )
+
+    splits = split_by_stages(df, y_col="y", stages=DEFAULT_STAGES)
+    assert set(splits) == {"stage_1", "stage_2"}
+    for stage_df in splits.values():
+        if not stage_df.empty:
+            assert "stage_label" in stage_df.columns
+            assert set(stage_df["stage_label"]) <= {"stage_1", "stage_2"}


### PR DESCRIPTION
## Summary
- add spreadsheet mapping, preprocessing and Arrhenius helper modules with stage segmentation utilities
- extend CLI and Gradio UI with new io/preprocess/arrhenius/features workflows and update feature engineering to build stage-aware stores
- expand test suite, documentation and examples to cover derivatives, Arrhenius fits and new pipeline

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d59c29485483278809dbc3d0791093