### PR TITLE
Add ML tuning commands and HTML reporting

### DIFF
--- a/ogum-ml-lite/ogum_lite/reports.py
+++ b/ogum-ml-lite/ogum_lite/reports.py
@@ -1,0 +1,184 @@
+"""HTML reporting helpers for Ogum ML Lite."""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.metrics import confusion_matrix
+
+
+def _figure_to_png_bytes(fig) -> bytes:
+    buffer = BytesIO()
+    fig.savefig(buffer, format="png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def plot_confusion_matrix(
+    y_true: np.ndarray, y_pred: np.ndarray, labels: Sequence[Any]
+) -> bytes:
+    """Render a confusion matrix plot and return PNG bytes."""
+
+    label_list = list(labels)
+    cm = confusion_matrix(y_true, y_pred, labels=label_list)
+    fig, ax = plt.subplots(figsize=(4, 4))
+    im = ax.imshow(cm)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("True")
+    tick_labels = [str(item) for item in label_list]
+    ax.set_xticks(range(len(label_list)))
+    ax.set_xticklabels(tick_labels, rotation=45, ha="right")
+    ax.set_yticks(range(len(label_list)))
+    ax.set_yticklabels(tick_labels)
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(j, i, int(cm[i, j]), ha="center", va="center", color="black")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+    fig.tight_layout()
+    return _figure_to_png_bytes(fig)
+
+
+def plot_regression_scatter(y_true: np.ndarray, y_pred: np.ndarray) -> bytes:
+    """Plot predictions versus true values and return PNG bytes."""
+
+    fig, ax = plt.subplots(figsize=(5, 4))
+    ax.scatter(y_true, y_pred, alpha=0.7, s=30)
+    limits = [min(np.min(y_true), np.min(y_pred)), max(np.max(y_true), np.max(y_pred))]
+    ax.plot(limits, limits, linestyle="--", linewidth=1.5)
+    ax.set_xlabel("True")
+    ax.set_ylabel("Predicted")
+    ax.set_title("Predicted vs True")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    return _figure_to_png_bytes(fig)
+
+
+def plot_feature_importance(imp_df: pd.DataFrame) -> bytes:
+    """Generate a bar chart with permutation importances."""
+
+    sorted_df = imp_df.sort_values("importance_mean", ascending=False)
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.barh(
+        sorted_df["feature"],
+        sorted_df["importance_mean"],
+        xerr=sorted_df["importance_std"],
+    )
+    ax.invert_yaxis()
+    ax.set_xlabel("Importance (mean Δ score)")
+    ax.set_title("Permutation feature importance")
+    fig.tight_layout()
+    return _figure_to_png_bytes(fig)
+
+
+def _dict_to_html_list(data: dict[str, Any]) -> str:
+    items: list[str] = []
+    for key, value in data.items():
+        items.append(f"<li><strong>{key}</strong>: {value}</li>")
+    return "\n".join(items)
+
+
+def render_html_report(outdir: Path, context: dict, figures: dict[str, bytes]) -> Path:
+    """Generate an HTML report embedding PNG figures as base64 images."""
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    figure_entries: list[str] = []
+    for name, data in figures.items():
+        filename = outdir / f"{name}.png"
+        filename.write_bytes(data)
+        encoded = base64.b64encode(data).decode("ascii")
+        figure_entries.append(
+            f"<figure><img alt='{name}' src='data:image/png;base64,{encoded}' />"
+            f"<figcaption>{name.replace('_', ' ').title()}</figcaption></figure>"
+        )
+
+    title = context.get("title", "Ogum ML Report")
+    task = context.get("task", "unknown")
+    metrics = context.get("metrics", {})
+    cv_metrics = context.get("cv_metrics", {})
+    best_params = context.get("best_params", {})
+    dataset_info = context.get("dataset", {})
+    features = context.get("features", [])
+    timestamp = context.get("timestamp", "")
+    observations = context.get("observations", "")
+
+    html = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <title>{title}</title>
+        <style>
+          body {{ font-family: Arial, sans-serif; margin: 2rem; }}
+          header {{ margin-bottom: 2rem; }}
+          section {{ margin-bottom: 1.5rem; }}
+          figure {{ margin: 1rem 0; }}
+          img {{
+            max-width: 100%;
+            height: auto;
+            border: 1px solid #ccc;
+            padding: 0.5rem;
+          }}
+          ul {{ list-style: square; }}
+          code {{
+            background-color: #f5f5f5;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+          }}
+        </style>
+      </head>
+      <body>
+        <header>
+          <h1>{title}</h1>
+          <p>
+            <strong>Task:</strong> {task} |
+            <strong>Generated at:</strong> {timestamp}
+          </p>
+        </header>
+        <section>
+          <h2>Dataset</h2>
+          <ul>
+            {_dict_to_html_list(dataset_info)}
+          </ul>
+        </section>
+        <section>
+          <h2>Evaluation Metrics</h2>
+          <ul>
+            {_dict_to_html_list(metrics)}
+          </ul>
+        </section>
+        <section>
+          <h2>Cross-validation (tuning)</h2>
+          <ul>
+            {_dict_to_html_list(cv_metrics)}
+          </ul>
+        </section>
+        <section>
+          <h2>Best Hyperparameters</h2>
+          <pre>{best_params}</pre>
+        </section>
+        <section>
+          <h2>Features</h2>
+          <p>{', '.join(features)}</p>
+        </section>
+        <section>
+          <h2>Observations</h2>
+          <p>{observations}</p>
+        </section>
+        <section>
+          <h2>Figures</h2>
+          {''.join(figure_entries)}
+        </section>
+      </body>
+    </html>
+    """
+
+    report_path = outdir / "report.html"
+    report_path.write_text(html, encoding="utf-8")
+    return report_path

--- a/ogum-ml-lite/tests/test_tuning.py
+++ b/ogum-ml-lite/tests/test_tuning.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from ogum_lite.cli import cmd_ml_report
+from ogum_lite.ml_hooks import random_search_classifier, random_search_regressor
+
+
+@pytest.fixture()
+def synthetic_classifier_df() -> pd.DataFrame:
+    rng = np.random.default_rng(123)
+    groups = np.repeat(np.arange(6), 5)
+    n_samples = groups.size
+    x1 = rng.normal(size=n_samples)
+    x2 = rng.normal(size=n_samples)
+    logits = 0.8 * x1 - 0.5 * x2
+    probs = 1 / (1 + np.exp(-logits))
+    y = (probs > 0.5).astype(int)
+    return pd.DataFrame(
+        {
+            "sample_id": groups,
+            "f1": x1,
+            "f2": x2,
+            "target": y,
+        }
+    )
+
+
+@pytest.fixture()
+def synthetic_regressor_df() -> pd.DataFrame:
+    rng = np.random.default_rng(321)
+    groups = np.repeat(np.arange(5), 6)
+    n_samples = groups.size
+    x1 = rng.normal(size=n_samples)
+    x2 = rng.normal(size=n_samples)
+    noise = rng.normal(scale=0.1, size=n_samples)
+    y = 3.0 * x1 - 2.0 * x2 + noise
+    return pd.DataFrame(
+        {
+            "sample_id": groups,
+            "f1": x1,
+            "f2": x2,
+            "target": y,
+        }
+    )
+
+
+def test_random_search_classifier_creates_artifacts(
+    tmp_path: Path, synthetic_classifier_df: pd.DataFrame
+) -> None:
+    outdir = tmp_path / "cls"
+    result = random_search_classifier(
+        synthetic_classifier_df,
+        target_col="target",
+        group_col="sample_id",
+        feature_cols=["f1", "f2"],
+        outdir=outdir,
+        n_iter=5,
+        cv_splits=3,
+        random_state=7,
+    )
+
+    assert (outdir / "classifier_tuned.joblib").exists()
+    assert (outdir / "param_grid.json").exists()
+    assert (outdir / "cv_results.json").exists()
+    card_path = outdir / "model_card.json"
+    assert card_path.exists()
+    payload = json.loads(card_path.read_text(encoding="utf-8"))
+    assert "best_params" in payload
+    assert result["cv"]["accuracy_mean"] >= 0.0
+
+
+def test_random_search_regressor_and_report(
+    tmp_path: Path,
+    synthetic_regressor_df: pd.DataFrame,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    outdir = tmp_path / "reg"
+    table_path = tmp_path / "features.csv"
+    synthetic_regressor_df.to_csv(table_path, index=False)
+
+    result = random_search_regressor(
+        synthetic_regressor_df,
+        target_col="target",
+        group_col="sample_id",
+        feature_cols=["f1", "f2"],
+        outdir=outdir,
+        n_iter=5,
+        cv_splits=3,
+        random_state=11,
+    )
+    assert "mae_mean" in result["cv"]
+
+    args = Namespace(
+        table=table_path,
+        target="target",
+        group_col="sample_id",
+        model=outdir / "regressor_tuned.joblib",
+        outdir=outdir,
+        n_repeats=3,
+        random_state=0,
+        notes="Smoke test",
+    )
+    cmd_ml_report(args)
+    captured = capsys.readouterr()
+    assert "Report metrics" in captured.out
+    report_path = outdir / "report.html"
+    assert report_path.exists()
+    html = report_path.read_text(encoding="utf-8")
+    assert "MAE" in html
+    assert (outdir / "regression_scatter.png").exists()
+    assert (outdir / "feature_importance.png").exists()


### PR DESCRIPTION
## Summary
- add RandomizedSearch-based tuning hooks and permutation importance utilities for ML pipelines
- extend the CLI with tuning/report commands and generate HTML reports with embedded figures
- document the new workflow and cover it with smoke tests

## Testing
- ruff check .
- black --check .
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6b112d1988327b80d1096a2c45bc4