### PR TITLE
Add validation tooling, exporters, and release automation

### DIFF
--- a/ogum-ml-lite/.github/workflows/release.yml
+++ b/ogum-ml-lite/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --outdir dist
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          name: Ogum ML Lite ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          allowUpdates: true
+          artifacts: "dist/*.whl,artifacts/**/*"
+          artifactErrorsFailBuild: false

--- a/ogum-ml-lite/docker/Dockerfile
+++ b/ogum-ml-lite/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /opt/ogum
+
+COPY pyproject.toml README.md LICENSE ./
+COPY ogum_lite ./ogum_lite
+COPY artifacts ./artifacts
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir .
+
+RUN useradd --create-home --shell /bin/bash ogum
+USER ogum
+WORKDIR /work
+
+ENTRYPOINT ["python", "-m", "ogum_lite.cli"]
+CMD ["--help"]

--- a/ogum-ml-lite/ogum_lite/exporters.py
+++ b/ogum-ml-lite/ogum_lite/exporters.py
@@ -1,0 +1,145 @@
+"""Export helpers for reports and interoperable artifacts."""
+
+from __future__ import annotations
+
+import importlib
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+try:  # pragma: no cover - imported lazily for images
+    from openpyxl.drawing.image import Image as XLImage
+except Exception:  # pragma: no cover - defensive fallback when openpyxl missing
+    XLImage = None  # type: ignore[assignment]
+
+
+def _flatten_context(context: dict[str, Any]) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+
+    def _append(prefix: str, value: Any) -> None:
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                _append(f"{prefix}.{sub_key}" if prefix else str(sub_key), sub_value)
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                _append(f"{prefix}[{index}]", item)
+        else:
+            rows.append({"item": prefix, "value": value})
+
+    for key, value in context.items():
+        _append(str(key), value)
+
+    if not rows:
+        return pd.DataFrame(columns=["item", "value"])
+    return pd.DataFrame(rows)
+
+
+def _ensure_dataframe(payload: Any) -> pd.DataFrame:
+    if isinstance(payload, pd.DataFrame):
+        return payload
+    if payload is None:
+        return pd.DataFrame()
+    if isinstance(payload, dict):
+        return pd.DataFrame(sorted(payload.items()), columns=["metric", "value"])
+    if isinstance(payload, list):
+        return pd.DataFrame(payload)
+    return pd.DataFrame([{"value": payload}])
+
+
+def export_xlsx(
+    out_path: Path,
+    *,
+    context: dict[str, Any],
+    tables: dict[str, pd.DataFrame],
+    images: dict[str, bytes] | None = None,
+) -> Path:
+    """Export an Excel report consolidating tables and optional figures."""
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    summary_df = _flatten_context(context)
+
+    def _fetch_table(*keys: str) -> pd.DataFrame | None:
+        for key in keys:
+            value = tables.get(key)
+            if value is not None:
+                return value
+        return None
+
+    msc_df = _ensure_dataframe(_fetch_table("MSC", "msc"))
+    features_df = _ensure_dataframe(_fetch_table("Features", "features"))
+    metrics_df = _ensure_dataframe(_fetch_table("Metrics", "metrics"))
+
+    with pd.ExcelWriter(out_path, engine="openpyxl") as writer:
+        summary_df.to_excel(writer, sheet_name="Summary", index=False)
+        msc_df.to_excel(writer, sheet_name="MSC", index=False)
+        features_df.to_excel(writer, sheet_name="Features", index=False)
+        metrics_df.to_excel(writer, sheet_name="Metrics", index=False)
+
+        if images:
+            workbook = writer.book
+            mapping = {
+                "msc.png": ("MSC", "H2"),
+                "confusion.png": ("Metrics", "H2"),
+                "scatter.png": ("Metrics", "H18"),
+            }
+            for key, (sheet, anchor) in mapping.items():
+                data = images.get(key)
+                if not data or XLImage is None:
+                    continue
+                worksheet = workbook[sheet]
+                image = XLImage(BytesIO(data))
+                worksheet.add_image(image, anchor)
+
+    return out_path
+
+
+def export_onnx(
+    sklearn_model: Any,
+    feature_names: list[str],
+    out_path: Path,
+) -> Path | None:
+    """Export a RandomForest model to ONNX if optional deps are available."""
+
+    estimator = sklearn_model
+    if hasattr(estimator, "named_steps"):
+        estimator = (
+            estimator.named_steps.get("model")
+            or list(estimator.named_steps.values())[-1]
+        )
+
+    from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
+    if not isinstance(estimator, (RandomForestClassifier, RandomForestRegressor)):
+        return None
+
+    try:
+        skl2onnx = importlib.import_module("skl2onnx")
+        data_types = importlib.import_module("skl2onnx.common.data_types")
+        convert_func = getattr(skl2onnx, "convert_sklearn")
+        tensor_type = getattr(data_types, "FloatTensorType")
+    except ImportError:
+        try:
+            onnxmltools = importlib.import_module("onnxmltools")
+            convert_func = getattr(onnxmltools, "convert_sklearn")
+            data_types = importlib.import_module(
+                "onnxmltools.convert.common.data_types"
+            )
+            tensor_type = getattr(data_types, "FloatTensorType")
+        except ImportError:
+            return None
+
+    if not feature_names:
+        return None
+
+    initial_types = [("input", tensor_type([None, len(feature_names)]))]
+    onnx_model = convert_func(estimator, initial_types=initial_types)
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("wb") as handle:
+        handle.write(onnx_model.SerializeToString())
+    return out_path

--- a/ogum-ml-lite/ogum_lite/validators.py
+++ b/ogum-ml-lite/ogum_lite/validators.py
@@ -1,0 +1,200 @@
+"""Validation helpers for Ogum Lite datasets."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from typing import Any
+
+import pandas as pd
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+
+class LongRow(BaseModel):
+    """Schema for the long-format experimental table."""
+
+    sample_id: int | str
+    time_s: float = Field(ge=0)
+    temp_C: float = Field(ge=-50, le=2500)
+    rho_rel: float | None = None
+    shrinkage_rel: float | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+    @field_validator("time_s", "temp_C", mode="before")
+    @classmethod
+    def _cast_float(cls, value: Any) -> float:
+        if value is None:
+            raise ValueError("value cannot be null")
+        return float(value)
+
+    @field_validator("rho_rel", "shrinkage_rel", mode="before")
+    @classmethod
+    def _validate_relative(cls, value: Any) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        value = float(value)
+        if not 0 <= value <= 1:
+            raise ValueError("must be between 0 and 1 inclusive")
+        return value
+
+    @model_validator(mode="after")
+    def _check_targets(self) -> "LongRow":
+        if self.rho_rel is None and self.shrinkage_rel is None:
+            raise ValueError("expected rho_rel and/or shrinkage_rel per row")
+        return self
+
+
+class FeatureRow(BaseModel):
+    """Schema for per-sample feature tables."""
+
+    sample_id: int | str
+    heating_rate_med_C_per_s: float = Field(ge=0)
+    T_max_C: float = Field(ge=-50, le=2500)
+    y_final: float = Field(ge=0, le=1)
+    t_to_90pct_s: float = Field(ge=0)
+    dy_dt_max: float = Field(ge=0)
+    T_at_dy_dt_max_C: float = Field(ge=-50, le=2500)
+
+    model_config = ConfigDict(extra="allow")
+
+    @field_validator(
+        "heating_rate_med_C_per_s",
+        "T_max_C",
+        "y_final",
+        "t_to_90pct_s",
+        "dy_dt_max",
+        "T_at_dy_dt_max_C",
+        mode="before",
+    )
+    @classmethod
+    def _cast_numeric(cls, value: Any) -> float:
+        if value is None:
+            raise ValueError("value cannot be null")
+        return float(value)
+
+    @model_validator(mode="after")
+    def _normalise_theta_columns(self) -> "FeatureRow":
+        for key, value in list(self.__dict__.items()):
+            if not key.startswith("theta_Ea_"):
+                continue
+            if value is None or (isinstance(value, float) and math.isnan(value)):
+                setattr(self, key, None)
+                continue
+            try:
+                setattr(self, key, float(value))
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError(f"{key} must be numeric") from exc
+        return self
+
+
+def _nan_report(df: pd.DataFrame, columns: Iterable[str]) -> list[str]:
+    issues: list[str] = []
+    for column in columns:
+        if column not in df.columns:
+            continue
+        pct = float(df[column].isna().mean() * 100)
+        if pct > 0:
+            issues.append(f"NaN ratio for column '{column}': {pct:.2f}%")
+    return issues
+
+
+def _sample_indices(length: int) -> list[int]:
+    if length == 0:
+        return []
+    step = max(length // 50, 1)
+    indices = list(range(0, length, step))
+    if indices[-1] != length - 1:
+        indices.append(length - 1)
+    return indices
+
+
+def validate_long_df(df: pd.DataFrame, *, y_col: str = "rho_rel") -> dict[str, Any]:
+    """Validate long-format dataframe and collect issues."""
+
+    issues: list[str] = []
+    required_columns = {"sample_id", "time_s", "temp_C"}
+    missing = sorted(col for col in required_columns if col not in df.columns)
+    if missing:
+        issues.append("Missing columns: " + ", ".join(missing))
+
+    target_columns = {y_col, "rho_rel", "shrinkage_rel"} & set(df.columns)
+    if not target_columns:
+        issues.append(
+            "Missing densification column: expected one of "
+            + ", ".join(sorted({y_col, "rho_rel", "shrinkage_rel"}))
+        )
+
+    issues.extend(
+        _nan_report(df, required_columns | {y_col, "rho_rel", "shrinkage_rel"})
+    )
+
+    for idx in _sample_indices(len(df)):
+        row = df.iloc[idx].to_dict()
+        row_payload = {
+            "sample_id": row.get("sample_id"),
+            "time_s": row.get("time_s"),
+            "temp_C": row.get("temp_C"),
+            "rho_rel": row.get("rho_rel"),
+            "shrinkage_rel": row.get("shrinkage_rel"),
+        }
+        if y_col in row:
+            # Override rho_rel with the selected target column when applicable.
+            if y_col == "shrinkage_rel":
+                row_payload["shrinkage_rel"] = row.get(y_col)
+            else:
+                row_payload["rho_rel"] = row.get(y_col)
+        try:
+            LongRow.model_validate(row_payload)
+        except ValidationError as exc:
+            for error in exc.errors():
+                location = "->".join(str(piece) for piece in error.get("loc", ()))
+                issues.append(f"Row {idx}: {location} {error.get('msg')}")
+
+    return {"ok": not issues, "issues": issues}
+
+
+def validate_feature_df(df: pd.DataFrame) -> dict[str, Any]:
+    """Validate per-sample feature dataframe."""
+
+    issues: list[str] = []
+    required_columns = {
+        "sample_id",
+        "heating_rate_med_C_per_s",
+        "T_max_C",
+        "y_final",
+        "t_to_90pct_s",
+        "dy_dt_max",
+        "T_at_dy_dt_max_C",
+    }
+    missing = sorted(col for col in required_columns if col not in df.columns)
+    if missing:
+        issues.append("Missing columns: " + ", ".join(missing))
+
+    issues.extend(
+        _nan_report(
+            df,
+            required_columns
+            | {col for col in df.columns if col.startswith("theta_Ea_")},
+        )
+    )
+
+    for idx in _sample_indices(len(df)):
+        row = df.iloc[idx].to_dict()
+        try:
+            FeatureRow.model_validate(row)
+        except ValidationError as exc:
+            for error in exc.errors():
+                location = "->".join(str(piece) for piece in error.get("loc", ()))
+                issues.append(f"Row {idx}: {location} {error.get('msg')}")
+
+    return {"ok": not issues, "issues": issues}

--- a/ogum-ml-lite/pyproject.toml
+++ b/ogum-ml-lite/pyproject.toml
@@ -18,8 +18,21 @@ dependencies = [
     "joblib",
     "gradio",
     "openpyxl",
+    "pydantic",
     "xlrd",
 ]
+
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/huyraestevao/ogum-ml"
+Repository = "https://github.com/huyraestevao/ogum-ml"
+Issues = "https://github.com/huyraestevao/ogum-ml/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/ogum-ml-lite/tests/test_exporters.py
+++ b/ogum-ml-lite/tests/test_exporters.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pandas as pd
+import pytest
+from ogum_lite import exporters
+from ogum_lite.exporters import export_onnx, export_xlsx
+from openpyxl import load_workbook
+from sklearn.ensemble import RandomForestClassifier
+
+
+def test_export_xlsx_creates_expected_tabs(tmp_path) -> None:
+    out_path = tmp_path / "report.xlsx"
+    context = {
+        "dataset": {"name": "demo"},
+        "metrics": {"accuracy": 0.92},
+    }
+    tables = {
+        "MSC": pd.DataFrame({"activation_energy": [200.0], "mse": [0.01]}),
+        "Features": pd.DataFrame({"sample_id": ["s1"], "y_final": [0.9]}),
+        "Metrics": pd.DataFrame({"metric": ["accuracy"], "value": [0.92]}),
+    }
+
+    export_xlsx(out_path, context=context, tables=tables, images=None)
+
+    workbook = load_workbook(out_path)
+    sheetnames = set(workbook.sheetnames)
+    assert {"Summary", "MSC", "Features", "Metrics"}.issubset(sheetnames)
+
+
+def test_export_onnx_returns_none_when_optional_missing(monkeypatch, tmp_path) -> None:
+    model = RandomForestClassifier(n_estimators=1, random_state=0)
+    model.fit([[0.0, 1.0], [1.0, 0.0]], [0, 1])
+    out_path = tmp_path / "model.onnx"
+
+    def raise_importerror(name: str) -> None:
+        raise ImportError(name)
+
+    monkeypatch.setattr(exporters.importlib, "import_module", raise_importerror)
+
+    result = export_onnx(model, ["f1", "f2"], out_path)
+    assert result is None
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("skl2onnx") is None
+    and importlib.util.find_spec("onnxmltools") is None,
+    reason="ONNX conversion dependencies not installed",
+)
+def test_export_onnx_generates_file_when_deps_present(tmp_path) -> None:
+    model = RandomForestClassifier(n_estimators=1, random_state=0)
+    model.fit([[0.0, 1.0], [1.0, 0.0]], [0, 1])
+    out_path = tmp_path / "model.onnx"
+
+    result = export_onnx(model, ["f1", "f2"], out_path)
+    assert result is None or result.exists()

--- a/ogum-ml-lite/tests/test_validators.py
+++ b/ogum-ml-lite/tests/test_validators.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pandas as pd
+from ogum_lite.validators import validate_feature_df, validate_long_df
+
+
+def test_validate_long_df_detects_out_of_range() -> None:
+    df = pd.DataFrame(
+        {
+            "sample_id": ["a", "b"],
+            "time_s": [0.0, -1.0],
+            "temp_C": [25.0, 3000.0],
+            "rho_rel": [0.5, 1.5],
+        }
+    )
+
+    report = validate_long_df(df)
+    assert report["ok"] is False
+    joined = "\n".join(report["issues"])
+    assert "temp_C" in joined
+    assert "time_s" in joined
+
+
+def test_validate_long_df_accepts_valid_payload() -> None:
+    df = pd.DataFrame(
+        {
+            "sample_id": ["s1"],
+            "time_s": [12.5],
+            "temp_C": [1250.0],
+            "rho_rel": [0.82],
+        }
+    )
+
+    report = validate_long_df(df)
+    assert report["ok"] is True
+    assert report["issues"] == []
+
+
+def test_validate_feature_df_reports_nans_and_bounds() -> None:
+    df = pd.DataFrame(
+        {
+            "sample_id": ["x", "y"],
+            "heating_rate_med_C_per_s": [0.5, -0.2],
+            "T_max_C": [1350.0, 2600.0],
+            "y_final": [0.95, 1.1],
+            "t_to_90pct_s": [100.0, None],
+            "dy_dt_max": [0.01, float("nan")],
+            "T_at_dy_dt_max_C": [900.0, 800.0],
+        }
+    )
+
+    report = validate_feature_df(df)
+    assert report["ok"] is False
+    joined = "\n".join(report["issues"])
+    assert "NaN ratio" in joined
+    assert "T_max_C" in joined
+
+
+def test_validate_feature_df_accepts_theta_columns() -> None:
+    df = pd.DataFrame(
+        {
+            "sample_id": ["s1"],
+            "heating_rate_med_C_per_s": [1.2],
+            "T_max_C": [1450.0],
+            "y_final": [0.88],
+            "t_to_90pct_s": [95.0],
+            "dy_dt_max": [0.04],
+            "T_at_dy_dt_max_C": [1420.0],
+            "theta_Ea_200": [0.75],
+        }
+    )
+
+    report = validate_feature_df(df)
+    assert report["ok"] is True
+    assert report["issues"] == []


### PR DESCRIPTION
## Summary
- add pydantic-based validators for long-format and feature tables, expose CLI validation commands, and document the workflow
- introduce Excel and optional ONNX exporters with corresponding CLI subcommands, tests, and README guidance
- add Docker packaging, release automation, and update project metadata for distribution readiness

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7d438fe44832799e8abe087fc82c7