### PR TITLE
Add segmentation and mechanism analysis tools

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -20,6 +20,10 @@ de usar em Google Colab e pronto para integrações com pipelines de ML.
   `OgumLite.compute_theta_table` ou CLI.
 - **MSC robusta**: métrica segmentada (55–70–90%) para avaliar o colapso das
   curvas por amostra.
+- **Segmentação automática**: CLI `segmentation` com limiares 55–70–90% ou
+  modo data-driven simples.
+- **Mudança de mecanismo**: ajuste piecewise linear com AIC/BIC via
+  `cli mechanism`.
 - **Compatibilidade**: nomes de colunas (`sample_id`, `time_s`, `temp_C`,
   `rho_rel`) alinhados com Ogum 6.4 e notebooks do repositório
   [ogumsoftware](https://github.com/huyraestevao/ogumsoftware).
@@ -98,6 +102,17 @@ python -m ogum_lite.cli features build \
   --stages "0.55-0.70,0.70-0.90" \
   --theta-ea "200,250,300" \
   --out exports/feature_store.csv
+
+# 5) Segmentação automática (fixed/data)
+python -m ogum_lite.cli segmentation \
+  --input exports/derivatives.csv \
+  --mode fixed \
+  --out artifacts/segments.json
+
+# 6) Detecção de mudança de mecanismo (θ vs densificação)
+python -m ogum_lite.cli mechanism \
+  --theta exports/theta_Ea_300kJ.csv \
+  --out artifacts/mechanism.csv
 
 # Comandos legados
 python -m ogum_lite.cli features --input ...

--- a/ogum-ml-lite/ogum_lite/__init__.py
+++ b/ogum-ml-lite/ogum_lite/__init__.py
@@ -1,5 +1,6 @@
 """Ogum Lite package initialization."""
 
+from .blaine import fit_blaine_by_segments, fit_blaine_segment
 from .features import (
     aggregate_timeseries,
     arrhenius_feature_table,
@@ -7,14 +8,17 @@ from .features import (
     build_feature_table,
     build_stage_feature_tables,
     finite_diff,
+    segment_feature_table,
     theta_features,
 )
+from .mechanism import detect_mechanism_change
 from .ml_hooks import (
     kmeans_explore,
     predict_from_artifact,
     train_classifier,
     train_regressor,
 )
+from .segmentation import segment_dataframe
 from .theta_msc import (
     R_GAS_CONSTANT,
     MasterCurveResult,
@@ -32,10 +36,15 @@ __all__ = [
     "build_feature_table",
     "build_feature_store",
     "build_stage_feature_tables",
+    "detect_mechanism_change",
+    "fit_blaine_by_segments",
+    "fit_blaine_segment",
     "build_master_curve",
     "finite_diff",
     "kmeans_explore",
     "predict_from_artifact",
+    "segment_dataframe",
+    "segment_feature_table",
     "score_activation_energies",
     "theta_features",
     "train_classifier",

--- a/ogum-ml-lite/ogum_lite/blaine.py
+++ b/ogum-ml-lite/ogum_lite/blaine.py
@@ -1,0 +1,122 @@
+"""Blaine linearisation utilities for sintering segments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .segmentation import Segment
+
+
+@dataclass
+class BlaineResult:
+    sample_id: str | int | float | None
+    segment_index: int
+    method: str
+    n_points: int
+    n: float
+    slope: float
+    intercept: float
+    r2: float
+    mse: float
+    start_time_s: float
+    end_time_s: float
+    start_y: float
+    end_y: float
+
+    def to_dict(self) -> dict[str, float | int | str]:
+        return {
+            "sample_id": self.sample_id,
+            "segment_index": self.segment_index,
+            "method": self.method,
+            "n_points": self.n_points,
+            "n": self.n,
+            "slope": self.slope,
+            "intercept": self.intercept,
+            "r2": self.r2,
+            "mse": self.mse,
+            "start_time_s": self.start_time_s,
+            "end_time_s": self.end_time_s,
+            "start_y": self.start_y,
+            "end_y": self.end_y,
+        }
+
+
+def _linearise_blaine(time_s: np.ndarray, y: np.ndarray) -> tuple[float, float, float, float]:
+    mask = (time_s > 0) & (y > 0) & (y < 1)
+    if mask.sum() < 2:
+        return (float("nan"),) * 4
+
+    log_t = np.log(time_s[mask])
+    log_blaine = np.log(1.0 / (1.0 - y[mask]))
+    A = np.vstack([log_t, np.ones_like(log_t)]).T
+    coeffs, *_ = np.linalg.lstsq(A, log_blaine, rcond=None)
+    slope = float(coeffs[0])
+    intercept = float(coeffs[1])
+    predictions = slope * log_t + intercept
+    residuals = log_blaine - predictions
+    sse = float(np.sum(residuals**2))
+    mse = sse / log_t.size
+    sst = float(np.sum((log_blaine - np.mean(log_blaine)) ** 2))
+    r2 = 1.0 - sse / sst if sst > 0 else 1.0
+    return slope, intercept, r2, mse
+
+
+def fit_blaine_segment(time_s: Sequence[float], y: Sequence[float]) -> dict[str, float]:
+    time_arr = np.asarray(time_s, dtype=float)
+    y_arr = np.asarray(y, dtype=float)
+    slope, intercept, r2, mse = _linearise_blaine(time_arr, y_arr)
+    return {
+        "slope": slope,
+        "intercept": intercept,
+        "r2": r2,
+        "mse": mse,
+        "n": slope,
+    }
+
+
+def fit_blaine_by_segments(
+    df: pd.DataFrame,
+    segments: Iterable[Segment],
+    *,
+    t_col: str = "time_s",
+    y_col: str = "rho_rel",
+) -> list[BlaineResult]:
+    results: list[BlaineResult] = []
+    for segment in segments:
+        subset = df.loc[segment.indices].sort_values(t_col)
+        if subset.empty:
+            slope = intercept = r2 = mse = float("nan")
+            n_value = float("nan")
+        else:
+            stats = fit_blaine_segment(subset[t_col], subset[y_col])
+            slope = stats["slope"]
+            intercept = stats["intercept"]
+            r2 = stats["r2"]
+            mse = stats["mse"]
+            n_value = stats["n"]
+
+        results.append(
+            BlaineResult(
+                sample_id=segment.sample_id,
+                segment_index=segment.segment_index,
+                method=segment.method,
+                n_points=segment.n_points,
+                n=n_value,
+                slope=slope,
+                intercept=intercept,
+                r2=r2,
+                mse=mse,
+                start_time_s=segment.start_time_s,
+                end_time_s=segment.end_time_s,
+                start_y=segment.start_y,
+                end_y=segment.end_y,
+            )
+        )
+    return results
+
+
+__all__ = ["BlaineResult", "fit_blaine_segment", "fit_blaine_by_segments"]

--- a/ogum-ml-lite/ogum_lite/mechanism.py
+++ b/ogum-ml-lite/ogum_lite/mechanism.py
@@ -1,0 +1,206 @@
+"""Mechanism change detection using piecewise linear models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from .segmentation import PiecewiseLinearModel, fit_piecewise_linear
+
+
+@dataclass
+class MechanismModel:
+    n_segments: int
+    breakpoints: list[int]
+    total_sse: float
+    slopes: list[float]
+    intercepts: list[float]
+    n_points: int
+    criterion: float
+    baseline_criterion: float
+    change_detected: bool
+    breakpoint_theta: float | None
+    breakpoint_densification: float | None
+
+    def to_dict(self) -> dict[str, float | int | bool | None]:
+        return {
+            "n_segments": self.n_segments,
+            "breakpoints": self.breakpoints,
+            "total_sse": self.total_sse,
+            "slopes": self.slopes,
+            "intercepts": self.intercepts,
+            "n_points": self.n_points,
+            "criterion": self.criterion,
+            "baseline_criterion": self.baseline_criterion,
+            "change_detected": self.change_detected,
+            "breakpoint_theta": self.breakpoint_theta,
+            "breakpoint_densification": self.breakpoint_densification,
+        }
+
+
+def _model_from_piecewise(
+    model: PiecewiseLinearModel,
+    *,
+    baseline: float,
+    theta: np.ndarray,
+    densification: np.ndarray,
+    threshold: float,
+    criterion: str,
+    slope_delta_threshold: float,
+) -> MechanismModel:
+    slopes = [segment.slope for segment in model.segments]
+    intercepts = [segment.intercept for segment in model.segments]
+    crit = model.information_criterion(criterion)
+    slope_delta = max(np.abs(np.diff(slopes))) if len(slopes) > 1 else 0.0
+    change_detected = (
+        model.n_segments > 1
+        and (baseline - crit) > threshold
+        and slope_delta >= slope_delta_threshold
+    )
+
+    breakpoint_theta = None
+    breakpoint_densification = None
+    if change_detected:
+        first_break = model.breakpoints[0]
+        breakpoint_theta = float(theta[first_break - 1])
+        breakpoint_densification = float(densification[first_break - 1])
+
+    return MechanismModel(
+        n_segments=model.n_segments,
+        breakpoints=model.breakpoints,
+        total_sse=model.total_sse,
+        slopes=slopes,
+        intercepts=intercepts,
+        n_points=model.n_points,
+        criterion=crit,
+        baseline_criterion=baseline,
+        change_detected=change_detected,
+        breakpoint_theta=breakpoint_theta,
+        breakpoint_densification=breakpoint_densification,
+    )
+
+
+def detect_mechanism_change(
+    df: pd.DataFrame,
+    *,
+    group_col: str = "sample_id",
+    theta_col: str = "theta",
+    y_col: str = "densification",
+    max_segments: int = 2,
+    min_size: int = 5,
+    criterion: str = "bic",
+    threshold: float = 2.0,
+    slope_delta: float = 0.02,
+) -> pd.DataFrame:
+    """Detect mechanism changes by comparing piecewise linear fits."""
+
+    if theta_col not in df.columns:
+        raise KeyError(f"Column '{theta_col}' not present in dataframe")
+    if y_col not in df.columns:
+        raise KeyError(f"Column '{y_col}' not present in dataframe")
+
+    groups: Iterable[tuple[str | None, pd.DataFrame]]
+    if group_col in df.columns:
+        groups = df.groupby(group_col)
+    else:
+        groups = [(None, df)]
+
+    records: list[dict[str, float | int | bool | None | str]] = []
+
+    for sample_id, group in groups:
+        ordered = group.sort_values(theta_col)
+        theta_values = ordered[theta_col].to_numpy(dtype=float)
+        densification = ordered[y_col].to_numpy(dtype=float)
+
+        if theta_values.size < min_size:
+            records.append(
+                {
+                    group_col: sample_id,
+                    "change_detected": False,
+                    "n_segments": 1,
+                    "criterion": float("nan"),
+                    "baseline_criterion": float("nan"),
+                    "breakpoint_theta": float("nan"),
+                    "breakpoint_densification": float("nan"),
+                }
+            )
+            continue
+
+        base_model = fit_piecewise_linear(theta_values, densification, 1, min_size=min_size)
+        if base_model is None:
+            records.append(
+                {
+                    group_col: sample_id,
+                    "change_detected": False,
+                    "n_segments": 1,
+                    "criterion": float("nan"),
+                    "baseline_criterion": float("nan"),
+                    "breakpoint_theta": float("nan"),
+                    "breakpoint_densification": float("nan"),
+                }
+            )
+            continue
+
+        baseline_score = base_model.information_criterion(criterion)
+        best_model = _model_from_piecewise(
+            base_model,
+            baseline=baseline_score,
+            theta=theta_values,
+            densification=densification,
+            threshold=threshold,
+            criterion=criterion,
+            slope_delta_threshold=slope_delta,
+        )
+
+        for n_segments in range(2, max_segments + 1):
+            candidate = fit_piecewise_linear(
+                theta_values, densification, n_segments, min_size=min_size
+            )
+            if candidate is None:
+                continue
+            candidate_model = _model_from_piecewise(
+                candidate,
+                baseline=baseline_score,
+                theta=theta_values,
+                densification=densification,
+                threshold=threshold,
+                criterion=criterion,
+                slope_delta_threshold=slope_delta,
+            )
+            if candidate_model.criterion < best_model.criterion:
+                best_model = candidate_model
+
+        if not best_model.change_detected and best_model.n_segments > 1:
+            best_model = _model_from_piecewise(
+                base_model,
+                baseline=baseline_score,
+                theta=theta_values,
+                densification=densification,
+                threshold=threshold,
+                criterion=criterion,
+                slope_delta_threshold=slope_delta,
+            )
+
+        records.append(
+            {
+                group_col: sample_id,
+                "change_detected": best_model.change_detected,
+                "n_segments": best_model.n_segments,
+                "criterion": best_model.criterion,
+                "baseline_criterion": best_model.baseline_criterion,
+                "breakpoint_theta": best_model.breakpoint_theta
+                if best_model.breakpoint_theta is not None
+                else float("nan"),
+                "breakpoint_densification": best_model.breakpoint_densification
+                if best_model.breakpoint_densification is not None
+                else float("nan"),
+            }
+        )
+
+    return pd.DataFrame.from_records(records)
+
+
+__all__ = ["MechanismModel", "detect_mechanism_change"]

--- a/ogum-ml-lite/ogum_lite/segmentation.py
+++ b/ogum-ml-lite/ogum_lite/segmentation.py
@@ -1,0 +1,357 @@
+"""Automatic segmentation utilities for densification curves."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class Segment:
+    """Summary of a segmentation interval for a single sample."""
+
+    sample_id: str | int | float | None
+    segment_index: int
+    method: str
+    lower: float
+    upper: float
+    start_time_s: float
+    end_time_s: float
+    start_y: float
+    end_y: float
+    n_points: int
+    indices: np.ndarray = field(repr=False)
+
+    def to_dict(self) -> dict[str, float | int | str]:
+        return {
+            "sample_id": self.sample_id,
+            "segment_index": self.segment_index,
+            "method": self.method,
+            "lower": self.lower,
+            "upper": self.upper,
+            "start_time_s": self.start_time_s,
+            "end_time_s": self.end_time_s,
+            "start_y": self.start_y,
+            "end_y": self.end_y,
+            "n_points": self.n_points,
+        }
+
+
+@dataclass
+class LinearSegmentStats:
+    start: int
+    end: int
+    slope: float
+    intercept: float
+    sse: float
+    r2: float
+    mse: float
+
+
+@dataclass
+class PiecewiseLinearModel:
+    segments: list[LinearSegmentStats]
+    breakpoints: list[int]
+    total_sse: float
+    n_points: int
+
+    @property
+    def n_segments(self) -> int:
+        return len(self.segments)
+
+    @property
+    def n_parameters(self) -> int:
+        # slope + intercept per segment, plus (segments - 1) breakpoints
+        return 2 * self.n_segments + max(0, self.n_segments - 1)
+
+    def information_criterion(self, criterion: str = "bic") -> float:
+        return compute_information_criterion(
+            self.total_sse, self.n_points, self.n_parameters, criterion=criterion
+        )
+
+
+def compute_information_criterion(
+    sse: float, n_points: int, n_parameters: int, *, criterion: str = "bic"
+) -> float:
+    """Compute AIC/BIC-like criteria from sum of squared errors."""
+
+    if n_points <= 0:
+        raise ValueError("n_points must be positive")
+    if n_parameters <= 0:
+        raise ValueError("n_parameters must be positive")
+    if criterion not in {"aic", "bic"}:
+        raise ValueError("criterion must be 'aic' or 'bic'")
+
+    sse = float(sse)
+    if sse <= 0.0:
+        # Guard against log(0) when the fit is perfect
+        sse = 1e-12
+    mse = sse / float(n_points)
+    penalty = 2 * n_parameters if criterion == "aic" else n_parameters * np.log(n_points)
+    return n_points * float(np.log(mse)) + penalty
+
+
+def _linear_stats(x: np.ndarray, y: np.ndarray, start: int, end: int) -> LinearSegmentStats:
+    segment_x = x[start:end]
+    segment_y = y[start:end]
+    if segment_x.size < 2:
+        return LinearSegmentStats(
+            start=start,
+            end=end,
+            slope=float("nan"),
+            intercept=float("nan"),
+            sse=float("nan"),
+            r2=float("nan"),
+            mse=float("nan"),
+        )
+
+    A = np.vstack([segment_x, np.ones_like(segment_x)]).T
+    coeffs, *_ = np.linalg.lstsq(A, segment_y, rcond=None)
+    slope = float(coeffs[0])
+    intercept = float(coeffs[1])
+    predictions = slope * segment_x + intercept
+    residuals = segment_y - predictions
+    sse = float(np.sum(residuals**2))
+    sst = float(np.sum((segment_y - np.mean(segment_y)) ** 2))
+    r2 = 1.0 - sse / sst if sst > 0 else 1.0
+    mse = sse / segment_x.size
+    return LinearSegmentStats(
+        start=start,
+        end=end,
+        slope=slope,
+        intercept=intercept,
+        sse=sse,
+        r2=r2,
+        mse=mse,
+    )
+
+
+def _iter_endpoints(n_points: int, n_segments: int, min_size: int) -> Iterable[list[int]]:
+    if n_segments <= 0:
+        raise ValueError("n_segments must be positive")
+    if min_size <= 0:
+        raise ValueError("min_size must be positive")
+
+    def backtrack(start: int, remaining: int, acc: List[int]) -> Iterable[list[int]]:
+        if remaining == 1:
+            if n_points - start >= min_size:
+                yield [*acc, n_points]
+            return
+        max_end = n_points - min_size * (remaining - 1)
+        for end in range(start + min_size, max_end + 1):
+            yield from backtrack(end, remaining - 1, [*acc, end])
+
+    return backtrack(0, n_segments, [])
+
+
+def fit_piecewise_linear(
+    x: np.ndarray,
+    y: np.ndarray,
+    n_segments: int,
+    *,
+    min_size: int = 5,
+) -> PiecewiseLinearModel | None:
+    """Fit a piecewise linear model with a fixed number of segments."""
+
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    if x.size != y.size:
+        raise ValueError("x and y must have the same length")
+    if x.size < n_segments * min_size:
+        return None
+
+    best_model: PiecewiseLinearModel | None = None
+    best_sse = float("inf")
+
+    for endpoints in _iter_endpoints(x.size, n_segments, min_size):
+        start = 0
+        segments: list[LinearSegmentStats] = []
+        total_sse = 0.0
+        for end in endpoints:
+            stats = _linear_stats(x, y, start, end)
+            if not np.isfinite(stats.sse):
+                total_sse = float("inf")
+                break
+            segments.append(stats)
+            total_sse += stats.sse
+            start = end
+        if total_sse < best_sse:
+            best_sse = total_sse
+            best_model = PiecewiseLinearModel(
+                segments=segments,
+                breakpoints=endpoints,
+                total_sse=total_sse,
+                n_points=x.size,
+            )
+
+    return best_model
+
+
+def segment_fixed(
+    time_s: np.ndarray,
+    y: np.ndarray,
+    *,
+    thresholds: Sequence[float] = (0.55, 0.70, 0.90),
+) -> list[tuple[int, int, float, float]]:
+    """Segment using predefined densification thresholds."""
+
+    bounds = [0.0, *thresholds, 1.0]
+    bounds = [max(0.0, float(b)) for b in bounds]
+    segments: list[tuple[int, int, float, float]] = []
+    for idx in range(len(bounds) - 1):
+        lower = bounds[idx]
+        upper = bounds[idx + 1]
+        if idx == len(bounds) - 2:
+            mask = (y >= lower) & (y <= upper)
+        else:
+            mask = (y >= lower) & (y < upper)
+        indices = np.where(mask)[0]
+        if indices.size == 0:
+            continue
+        segments.append((indices[0], indices[-1] + 1, lower, upper))
+    return segments
+
+
+def segment_data_driven(
+    time_s: np.ndarray,
+    y: np.ndarray,
+    *,
+    n_segments: int = 3,
+    min_size: int = 5,
+) -> list[tuple[int, int, float, float]]:
+    """Segment using a simple piecewise-linear search over the curve."""
+
+    model = fit_piecewise_linear(time_s, y, n_segments, min_size=min_size)
+    if model is None:
+        return []
+
+    segments: list[tuple[int, int, float, float]] = []
+    start = 0
+    for stats in model.segments:
+        end = stats.end
+        segment_y = y[start:end]
+        lower = float(segment_y.min())
+        upper = float(segment_y.max())
+        segments.append((start, end, lower, upper))
+        start = end
+    return segments
+
+
+def segment_group(
+    group: pd.DataFrame,
+    *,
+    t_col: str,
+    y_col: str,
+    method: str = "fixed",
+    thresholds: Sequence[float] = (0.55, 0.70, 0.90),
+    n_segments: int = 3,
+    min_size: int = 5,
+    sample_value: str | int | float | None = None,
+    group_col: str = "sample_id",
+) -> list[Segment]:
+    """Segment a single group of densification measurements."""
+
+    ordered = group.sort_values(t_col)
+    time = ordered[t_col].to_numpy(dtype=float)
+    y = ordered[y_col].to_numpy(dtype=float)
+    index = ordered.index.to_numpy()
+
+    if method == "fixed":
+        raw_segments = segment_fixed(time, y, thresholds=thresholds)
+    elif method == "data":
+        raw_segments = segment_data_driven(time, y, n_segments=n_segments, min_size=min_size)
+    else:
+        raise ValueError("method must be 'fixed' or 'data'")
+
+    results: list[Segment] = []
+    if sample_value is None and group_col in ordered.columns:
+        series = ordered[group_col]
+        if series.nunique() == 1:
+            sample_value = series.iloc[0]
+
+    for idx, (start_pos, end_pos, lower, upper) in enumerate(raw_segments, start=1):
+        local_indices = index[start_pos:end_pos]
+        segment_time = time[start_pos:end_pos]
+        segment_y = y[start_pos:end_pos]
+        results.append(
+            Segment(
+                sample_id=sample_value,
+                segment_index=idx,
+                method=method,
+                lower=lower,
+                upper=upper,
+                start_time_s=float(segment_time[0]),
+                end_time_s=float(segment_time[-1]),
+                start_y=float(segment_y[0]),
+                end_y=float(segment_y[-1]),
+                n_points=int(local_indices.size),
+                indices=local_indices,
+            )
+        )
+    return results
+
+
+def segment_dataframe(
+    df: pd.DataFrame,
+    *,
+    group_col: str = "sample_id",
+    t_col: str = "time_s",
+    y_col: str = "rho_rel",
+    method: str = "fixed",
+    thresholds: Sequence[float] = (0.55, 0.70, 0.90),
+    n_segments: int = 3,
+    min_size: int = 5,
+) -> list[Segment]:
+    """Segment an entire dataframe across all samples."""
+
+    if y_col not in df.columns:
+        raise KeyError(f"Column '{y_col}' not present in dataframe")
+    if t_col not in df.columns:
+        raise KeyError(f"Column '{t_col}' not present in dataframe")
+
+    if group_col in df.columns:
+        grouped = df.groupby(group_col)
+        segments = []
+        for sample_value, group in grouped:
+            segments.extend(
+                segment_group(
+                    group,
+                    t_col=t_col,
+                    y_col=y_col,
+                    method=method,
+                    thresholds=thresholds,
+                    n_segments=n_segments,
+                    min_size=min_size,
+                    sample_value=sample_value,
+                    group_col=group_col,
+                )
+            )
+        return segments
+
+    return segment_group(
+        df,
+        t_col=t_col,
+        y_col=y_col,
+        method=method,
+        thresholds=thresholds,
+        n_segments=n_segments,
+        min_size=min_size,
+        group_col=group_col,
+    )
+
+
+__all__ = [
+    "Segment",
+    "LinearSegmentStats",
+    "PiecewiseLinearModel",
+    "compute_information_criterion",
+    "fit_piecewise_linear",
+    "segment_dataframe",
+    "segment_data_driven",
+    "segment_fixed",
+    "segment_group",
+]

--- a/ogum-ml-lite/tests/test_blaine.py
+++ b/ogum-ml-lite/tests/test_blaine.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from ogum_lite.blaine import fit_blaine_by_segments, fit_blaine_segment
+from ogum_lite.segmentation import Segment
+
+
+def test_blaine_linearisation_returns_expected_exponent() -> None:
+    time = np.linspace(1.0, 5.0, 20)
+    y = 1.0 - 1.0 / (time**2)
+
+    stats = fit_blaine_segment(time, y)
+
+    assert stats["n"] == pytest.approx(2.0, abs=1e-3)
+    assert stats["r2"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_blaine_by_segments_uses_segment_indices() -> None:
+    time = np.linspace(1.0, 4.0, 15)
+    y = 1.0 - 1.0 / (time**2)
+    df = pd.DataFrame({"sample_id": "A", "time_s": time, "rho_rel": y})
+
+    segment = Segment(
+        sample_id="A",
+        segment_index=1,
+        method="fixed",
+        lower=float(y.min()),
+        upper=float(y.max()),
+        start_time_s=float(time[0]),
+        end_time_s=float(time[-1]),
+        start_y=float(y[0]),
+        end_y=float(y[-1]),
+        n_points=len(time),
+        indices=df.index.to_numpy(),
+    )
+
+    results = fit_blaine_by_segments(df, [segment], t_col="time_s", y_col="rho_rel")
+    assert len(results) == 1
+    result = results[0]
+    assert result.sample_id == "A"
+    assert result.n == pytest.approx(2.0, abs=1e-3)
+    assert result.r2 == pytest.approx(1.0, abs=1e-6)
+    assert result.mse < 1e-6

--- a/ogum-ml-lite/tests/test_features.py
+++ b/ogum-ml-lite/tests/test_features.py
@@ -97,6 +97,8 @@ def test_build_feature_store_stage_columns_present() -> None:
         suffix = f"_s{idx}"
         assert any(column.endswith(suffix) for column in feature_store.columns)
     assert "Ea_arr_global_kJ" in feature_store.columns
+    assert any(column.startswith("fixed_seg1") for column in feature_store.columns)
+    assert "fixed_seg1_blaine_n" in feature_store.columns
 
 
 def test_theta_features_and_feature_table() -> None:

--- a/ogum-ml-lite/tests/test_mechanism.py
+++ b/ogum-ml-lite/tests/test_mechanism.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from ogum_lite.mechanism import detect_mechanism_change
+
+
+def test_mechanism_change_detected_in_piecewise_curve() -> None:
+    theta = np.linspace(0.0, 10.0, 200)
+    densification = np.piecewise(
+        theta,
+        [theta < 5.0, theta >= 5.0],
+        [lambda t: 0.2 + 0.05 * t, lambda t: 0.45 + 0.09 * (t - 5.0)],
+    )
+    df = pd.DataFrame(
+        {
+            "sample_id": "S1",
+            "theta": theta,
+            "densification": densification,
+        }
+    )
+
+    result = detect_mechanism_change(df)
+    row = result.iloc[0]
+    assert bool(row["change_detected"])
+    assert row["n_segments"] == 2
+    assert row["breakpoint_theta"] == pytest.approx(5.0, abs=0.3)
+
+
+def test_mechanism_no_change_for_linear_relation() -> None:
+    theta = np.linspace(0.0, 10.0, 150)
+    densification = 0.25 + 0.07 * theta
+    df = pd.DataFrame(
+        {
+            "sample_id": "S2",
+            "theta": theta,
+            "densification": densification,
+        }
+    )
+
+    result = detect_mechanism_change(df)
+    row = result.iloc[0]
+    assert not bool(row["change_detected"])
+    assert row["n_segments"] == 1

--- a/ogum-ml-lite/tests/test_segmentation.py
+++ b/ogum-ml-lite/tests/test_segmentation.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from ogum_lite.segmentation import segment_dataframe
+
+
+def _build_dataframe() -> pd.DataFrame:
+    time = np.linspace(0, 10, 101)
+    rho = np.linspace(0.40, 0.95, 101)
+    return pd.DataFrame({"sample_id": "S1", "time_s": time, "rho_rel": rho})
+
+
+def test_fixed_segmentation_generates_expected_ranges() -> None:
+    df = _build_dataframe()
+    segments = segment_dataframe(
+        df,
+        method="fixed",
+        thresholds=(0.55, 0.70, 0.90),
+        group_col="sample_id",
+        t_col="time_s",
+        y_col="rho_rel",
+    )
+
+    assert len(segments) == 4
+    assert pytest.approx(segments[0].lower, rel=1e-6) == 0.0
+    assert pytest.approx(segments[-1].upper, rel=1e-6) == 1.0
+    assert all(segment.sample_id == "S1" for segment in segments)
+
+
+def test_data_driven_segmentation_detects_breakpoints() -> None:
+    time = np.linspace(0, 12, 120)
+    y = np.piecewise(
+        time,
+        [time < 4, (time >= 4) & (time < 8), time >= 8],
+        [
+            lambda t: 0.40 + 0.05 * t,
+            lambda t: 0.60 + 0.03 * (t - 4),
+            lambda t: 0.72 + 0.06 * (t - 8),
+        ],
+    )
+    df = pd.DataFrame({"sample_id": "S2", "time_s": time, "rho_rel": y})
+
+    segments = segment_dataframe(
+        df,
+        method="data",
+        n_segments=3,
+        min_size=10,
+        group_col="sample_id",
+        t_col="time_s",
+        y_col="rho_rel",
+    )
+
+    assert len(segments) == 3
+    assert segments[0].end_time_s == pytest.approx(4.0, abs=0.5)
+    assert segments[1].end_time_s == pytest.approx(8.0, abs=0.5)


### PR DESCRIPTION
## Summary
- add segmentation utilities with fixed thresholds or data-driven piecewise fitting and expose Blaine linearisation helpers
- implement mechanism change detection using piecewise linear models, integrate into the CLI, and augment the feature store with per-segment metrics
- document the new commands and provide dedicated unit tests for segmentation, Blaine, and mechanism workflows

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7e32dd0788327beb0f6e245d1f43a