### PR TITLE
Add interactive UI frontends and workspace utilities

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -30,6 +30,45 @@ de usar em Google Colab e pronto para integrações com pipelines de ML.
 - **Pronto para ML**: módulo `features` com engenharia global e stage-aware,
   integração com `theta_msc` e `ml_hooks` para pipelines supervisionados.
 
+## Frontend Alpha (Fase 7)
+
+Esta fase adiciona um frontend interativo completo para executar o pipeline
+Ogum Lite de ponta a ponta em dados reais.
+
+### Streamlit (painel principal)
+
+```bash
+streamlit run app/streamlit_app.py
+```
+
+O painel está organizado em abas que refletem o fluxo recomendado:
+
+1. **Workspace & Presets** – escolha o diretório base da sessão, carregue/edite
+   presets YAML e acompanhe o log de proveniência (`run_log.jsonl`).
+2. **Data Prep & Validate** – faça upload de CSV longos, execute validação com
+   `validators.validate_long_df` e acione `preprocess derive` via CLI.
+3. **Features** – derive a tabela de features, valide-a e visualize as primeiras
+   linhas diretamente no app.
+4. **θ / MSC** – compute θ(Ea), gere o colapso MSC (CSV/PNG) e baixe o pacote
+   de curvas `theta_curves.zip`.
+5. **Segmentação & Mecanismo** – rode segmentação (fixed/data) e o relatório de
+   mudança de mecanismo (Blaine/n) reaproveitando os módulos centrais.
+6. **ML** – treine classificadores/regressores, inspeccione o `model_card.json`
+   e gere predições usando artefatos do workspace.
+7. **Export** – consolide um relatório XLSX (`export xlsx`) e baixe um ZIP com
+   todos os artefatos da sessão.
+
+O preset padrão fica em `app/presets.yaml` e pode ser salvo/mesclado via UI.
+
+### Gradio (alternativa leve)
+
+```bash
+python app/gradio_app.py
+```
+
+O modo Gradio expõe um formulário compacto (upload → preset → executar) que
+orquestra os mesmos comandos CLI e disponibiliza o ZIP consolidado.
+
 ## Instalação
 
 ```bash

--- a/ogum-ml-lite/app/gradio_app.py
+++ b/ogum-ml-lite/app/gradio_app.py
@@ -1,0 +1,98 @@
+"""Minimal Gradio interface for the Ogum ML Lite pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import gradio as gr
+import yaml
+from ogum_lite.ui import orchestrator
+from ogum_lite.ui.presets import load_presets, merge_presets
+from ogum_lite.ui.workspace import Workspace
+
+APP_DIR = Path(__file__).parent
+DEFAULT_PRESET = APP_DIR / "presets.yaml"
+
+
+def _prepare_workspace() -> Workspace:
+    root = Path.cwd() / "artifacts" / "gradio-session"
+    return Workspace(root)
+
+
+def _serialize_log(ws: Workspace) -> str:
+    log_path = ws.resolve(ws.log_name)
+    if not log_path.exists():
+        return ""
+    tail = log_path.read_text(encoding="utf-8").strip().splitlines()[-8:]
+    return "\n".join(tail)
+
+
+def run_pipeline(
+    file: gr.File | None, preset_yaml: str | None
+) -> tuple[str, str | None]:
+    if file is None:
+        raise gr.Error("Envie um CSV longo para iniciar a pipeline.")
+
+    ws = _prepare_workspace()
+    preset = load_presets(DEFAULT_PRESET)
+    if preset_yaml:
+        try:
+            override = yaml.safe_load(preset_yaml) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - defensive
+            raise gr.Error(f"Preset inválido: {exc}") from exc
+        preset = merge_presets(preset, override)
+    upload_path = ws.resolve("uploads") / Path(file.name).name
+    upload_path.parent.mkdir(parents=True, exist_ok=True)
+    upload_path.write_bytes(Path(file.name).read_bytes())
+
+    try:
+        prep_csv = orchestrator.run_prep(upload_path, preset, ws)
+        features_csv = orchestrator.run_features(prep_csv, preset, ws)
+        theta_outputs = orchestrator.run_theta_msc(prep_csv, preset, ws)
+        orchestrator.run_segmentation(prep_csv, preset, ws)
+        orchestrator.run_mechanism(Path(theta_outputs["theta_table"]), preset, ws)
+        orchestrator.run_ml_train_cls(features_csv, preset, ws)
+    except Exception as exc:  # pragma: no cover - UI surface
+        return f"Erro na pipeline: {exc}", None
+
+    zip_path = orchestrator.build_report(ws.path, preset, ws)
+    log_tail = _serialize_log(ws)
+    return log_tail, str(zip_path)
+
+
+def main() -> None:
+    preset_text = (
+        DEFAULT_PRESET.read_text(encoding="utf-8") if DEFAULT_PRESET.exists() else ""
+    )
+
+    with gr.Blocks(title="Ogum ML Lite") as demo:
+        gr.Markdown("## Ogum ML Lite — Frontend Alpha (Gradio)")
+        with gr.Row():
+            file_input = gr.File(
+                label="CSV longo", file_types=[".csv"], file_count="single"
+            )
+            preset_input = gr.Textbox(
+                label="Preset YAML (opcional)",
+                lines=20,
+                value=preset_text,
+            )
+        run_btn = gr.Button("Executar pipeline")
+        log_output = gr.Textbox(label="Log", lines=12)
+        zip_output = gr.File(label="ZIP de artefatos")
+
+        def _callback(file: Any, preset: str) -> tuple[str, str | None]:
+            return run_pipeline(file, preset)
+
+        run_btn.click(
+            _callback,
+            inputs=[file_input, preset_input],
+            outputs=[log_output, zip_output],
+        )
+
+    if __name__ == "__main__":
+        demo.launch()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/ogum-ml-lite/app/presets.yaml
+++ b/ogum-ml-lite/app/presets.yaml
@@ -1,0 +1,38 @@
+columns:
+  group_col: sample_id
+  t_col: time_s
+  temp_col: temp_C
+  y_col: rho_rel
+prep:
+  enabled: true
+  smooth: savgol
+  window: 11
+  poly: 3
+  moving_k: 5
+  output: prep/ensaios_prep.csv
+msc:
+  ea_kj: [200, 300, 400]
+  metric: segmented
+  outdir: theta_msc
+segmentation:
+  mode: fixed
+  bounds:
+    - "0.55,0.70"
+    - "0.70,0.90"
+  output: segments/segments.json
+ml:
+  features:
+    - heating_rate_med_C_per_s
+    - T_max_C
+    - y_final
+    - t_to_90pct_s
+    - theta_Ea_200kJ
+    - theta_Ea_300kJ
+  cls_target: technique
+  reg_target: T90_C
+  cls_outdir: ml/classifier
+  reg_outdir: ml/regressor
+export:
+  outdir: artifacts/session-{{timestamp}}
+  report: reports/ogum_report.xlsx
+  zip: exports/session_artifacts.zip

--- a/ogum-ml-lite/app/streamlit_app.py
+++ b/ogum-ml-lite/app/streamlit_app.py
@@ -1,0 +1,376 @@
+"""Ogum ML Lite Streamlit dashboard."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+import yaml
+from ogum_lite.ui import orchestrator
+from ogum_lite.ui.presets import load_presets, merge_presets, save_presets
+from ogum_lite.ui.workspace import Workspace
+
+APP_DIR = Path(__file__).parent
+DEFAULT_PRESET_PATH = APP_DIR / "presets.yaml"
+
+
+def _load_default_preset() -> dict[str, Any]:
+    if "preset" in st.session_state:
+        return st.session_state["preset"]
+    preset = load_presets(DEFAULT_PRESET_PATH)
+    st.session_state["preset"] = preset
+    st.session_state["preset_yaml"] = yaml.safe_dump(
+        preset, sort_keys=False, allow_unicode=True
+    )
+    return preset
+
+
+def _get_workspace() -> Workspace:
+    root_text = st.session_state.get("workspace_root")
+    if not root_text:
+        default_root = Path.cwd() / "artifacts" / "ui-session"
+        st.session_state["workspace_root"] = str(default_root)
+        root_text = str(default_root)
+    workspace = Workspace(Path(root_text))
+    st.session_state["workspace"] = workspace
+    return workspace
+
+
+def _display_log(ws: Workspace) -> None:
+    log_path = ws.resolve(ws.log_name)
+    if not log_path.exists():
+        return
+    tail = log_path.read_text(encoding="utf-8").strip().splitlines()[-5:]
+    st.caption("Últimos eventos")
+    for line in tail:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            st.code(line)
+            continue
+        st.code(json.dumps(entry, indent=2, ensure_ascii=False))
+
+
+def _persist_uploaded(file, ws: Workspace) -> Path:
+    uploads_dir = ws.resolve("uploads")
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    target = uploads_dir / file.name
+    with target.open("wb") as handle:
+        handle.write(file.getbuffer())
+    return target
+
+
+def _yaml_editor(preset: dict[str, Any], ws: Workspace) -> dict[str, Any]:
+    st.subheader("Preset manager")
+    uploaded = st.file_uploader(
+        "Carregar preset YAML", type=["yml", "yaml"], key="preset_upload"
+    )
+    if uploaded is not None:
+        loaded = yaml.safe_load(uploaded.read()) or {}
+        merged = merge_presets(preset, loaded)
+        st.session_state["preset"] = merged
+        st.session_state["preset_yaml"] = yaml.safe_dump(
+            merged, sort_keys=False, allow_unicode=True
+        )
+        st.success("Preset carregado e mesclado com sucesso.")
+        preset = merged
+
+    preset_yaml = st.text_area(
+        "Preset YAML",
+        value=st.session_state.get(
+            "preset_yaml", yaml.safe_dump(preset, sort_keys=False, allow_unicode=True)
+        ),
+        height=360,
+    )
+    cols = st.columns(3)
+    if cols[0].button("Aplicar preset"):
+        try:
+            loaded = yaml.safe_load(preset_yaml) or {}
+        except yaml.YAMLError as exc:
+            st.error(f"Erro ao interpretar YAML: {exc}")
+        else:
+            st.session_state["preset"] = loaded
+            st.session_state["preset_yaml"] = yaml.safe_dump(
+                loaded, sort_keys=False, allow_unicode=True
+            )
+            preset = loaded
+            st.success("Preset atualizado.")
+    if cols[1].button("Restaurar padrão"):
+        fresh = load_presets(DEFAULT_PRESET_PATH)
+        st.session_state["preset"] = fresh
+        st.session_state["preset_yaml"] = yaml.safe_dump(
+            fresh, sort_keys=False, allow_unicode=True
+        )
+        preset = fresh
+        st.info("Preset padrão restaurado.")
+    if cols[2].button("Salvar preset no workspace"):
+        target = _timestamped_preset_path(ws)
+        save_presets(preset, target)
+        st.success(f"Preset salvo em {target}")
+    return preset
+
+
+def _timestamped_preset_path(ws: Workspace) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return ws.resolve(f"presets/preset-{timestamp}.yaml")
+
+
+def _show_dataframe(path: Path, caption: str, rows: int = 20) -> None:
+    if not path or not Path(path).exists():
+        return
+    df = pd.read_csv(path)
+    st.caption(caption)
+    st.dataframe(df.head(rows))
+
+
+def main() -> None:
+    st.set_page_config(page_title="Ogum ML Lite", layout="wide")
+    st.title("Ogum ML Lite — Frontend Alpha")
+
+    preset = _load_default_preset()
+    workspace = _get_workspace()
+
+    tabs = st.tabs(
+        [
+            "Workspace & Presets",
+            "Data Prep & Validate",
+            "Features",
+            "θ / MSC",
+            "Segmentação & Mecanismo",
+            "ML",
+            "Export",
+        ]
+    )
+
+    with tabs[0]:
+        st.subheader("Workspace")
+        root_input = st.text_input(
+            "Diretório base da sessão", value=st.session_state["workspace_root"]
+        )
+        if root_input and root_input != st.session_state["workspace_root"]:
+            st.session_state["workspace_root"] = root_input
+            workspace = _get_workspace()
+        st.caption(f"Workspace ativo: {workspace.path}")
+        preset = _yaml_editor(preset, workspace)
+        _display_log(workspace)
+
+    with tabs[1]:
+        st.subheader("Data Prep & Validação")
+        uploaded = st.file_uploader("Upload CSV longo", type=["csv"], key="long_upload")
+        if uploaded is not None:
+            input_path = _persist_uploaded(uploaded, workspace)
+            st.session_state["input_csv"] = str(input_path)
+            st.success(f"Arquivo salvo em {input_path}")
+        input_default = st.session_state.get("input_csv", "")
+        input_path_text = st.text_input(
+            "ou informe caminho existente", value=input_default
+        )
+        if input_path_text:
+            st.session_state["input_csv"] = input_path_text
+        input_csv = st.session_state.get("input_csv")
+
+        cols = st.columns(3)
+        if cols[0].button("Validar long", disabled=not input_csv):
+            with st.spinner("Validando dados longos..."):
+                result = orchestrator.run_validation(Path(input_csv), preset)
+            st.session_state["validation_long"] = result
+            st.json(result)
+        if cols[1].button("Pré-processar", disabled=not input_csv):
+            with st.spinner("Executando preprocess derive..."):
+                prep_csv = orchestrator.run_prep(Path(input_csv), preset, workspace)
+            st.session_state["prep_csv"] = str(prep_csv)
+            st.success(f"Derivadas salvas em {prep_csv}")
+        if cols[2].button("Recarregar preset base"):
+            preset = _load_default_preset()
+            st.info("Preset padrão recarregado para esta sessão.")
+        _display_log(workspace)
+
+    with tabs[2]:
+        st.subheader("Features")
+        prep_csv = st.session_state.get("prep_csv") or st.session_state.get("input_csv")
+        st.text_input(
+            "Arquivo base para features", value=prep_csv or "", key="features_input"
+        )
+        features_input = st.session_state.get("features_input")
+        cols = st.columns(2)
+        if cols[0].button("Gerar features", disabled=not features_input):
+            with st.spinner("Gerando tabela de features..."):
+                features_csv = orchestrator.run_features(
+                    Path(features_input), preset, workspace
+                )
+            st.session_state["features_csv"] = str(features_csv)
+            st.success(f"Tabela de features salva em {features_csv}")
+        if cols[1].button(
+            "Validar features", disabled=not st.session_state.get("features_csv")
+        ):
+            with st.spinner("Validando tabela de features..."):
+                report = orchestrator.run_feature_validation(
+                    Path(st.session_state["features_csv"])
+                )
+            st.session_state["validation_features"] = report
+            st.json(report)
+        if st.session_state.get("features_csv"):
+            _show_dataframe(
+                Path(st.session_state["features_csv"]), "Prévia das features"
+            )
+        _display_log(workspace)
+
+    with tabs[3]:
+        st.subheader("θ(Ea) & MSC")
+        base_csv = st.session_state.get("prep_csv") or st.session_state.get("input_csv")
+        if st.button("Rodar θ/MSC", disabled=not base_csv):
+            with st.spinner("Calculando θ(Ea) e MSC..."):
+                outputs = orchestrator.run_theta_msc(Path(base_csv), preset, workspace)
+            serialized: dict[str, Any] = {}
+            for key, value in outputs.items():
+                if isinstance(value, Path):
+                    serialized[key] = str(value)
+                else:
+                    serialized[key] = value
+            st.session_state["theta_outputs"] = serialized
+            st.success(f"Melhor Ea: {outputs['best_ea']}")
+        outputs = st.session_state.get("theta_outputs")
+        if outputs:
+            st.metric("Ea ótimo (kJ/mol)", outputs.get("best_ea"))
+            theta_table = outputs.get("theta_table")
+            if theta_table and Path(theta_table).exists():
+                _show_dataframe(Path(theta_table), "Tabela θ(Ea)")
+            msc_plot = outputs.get("msc_plot")
+            if msc_plot and Path(msc_plot).exists():
+                st.image(msc_plot, caption="Master Sintering Curve")
+            msc_curve = outputs.get("msc_curve")
+            if msc_curve and Path(msc_curve).exists():
+                st.download_button(
+                    "Baixar MSC CSV",
+                    data=Path(msc_curve).read_bytes(),
+                    file_name=Path(msc_curve).name,
+                )
+            theta_zip = outputs.get("theta_zip")
+            if theta_zip and Path(theta_zip).exists():
+                st.download_button(
+                    "Baixar θ(Ea) ZIP",
+                    data=Path(theta_zip).read_bytes(),
+                    file_name=Path(theta_zip).name,
+                )
+        _display_log(workspace)
+
+    with tabs[4]:
+        st.subheader("Segmentação & Mecanismo")
+        base_csv = st.session_state.get("prep_csv")
+        theta_table = None
+        if st.session_state.get("theta_outputs"):
+            theta_table = st.session_state["theta_outputs"].get("theta_table")
+        cols = st.columns(2)
+        if cols[0].button("Segmentação", disabled=not base_csv):
+            with st.spinner("Executando segmentação..."):
+                segments = orchestrator.run_segmentation(
+                    Path(base_csv), preset, workspace
+                )
+            st.session_state["segments_json"] = str(segments)
+            st.success(f"Segmentos salvos em {segments}")
+        if cols[1].button("Detectar mecanismo", disabled=not theta_table):
+            with st.spinner("Detectando mudança de mecanismo..."):
+                mechanism = orchestrator.run_mechanism(
+                    Path(theta_table), preset, workspace
+                )
+            st.session_state["mechanism_csv"] = str(mechanism)
+            st.success(f"Relatório salvo em {mechanism}")
+        if (
+            st.session_state.get("segments_json")
+            and Path(st.session_state["segments_json"]).exists()
+        ):
+            data = json.loads(Path(st.session_state["segments_json"]).read_text())
+            st.json(data)
+        if (
+            st.session_state.get("mechanism_csv")
+            and Path(st.session_state["mechanism_csv"]).exists()
+        ):
+            _show_dataframe(
+                Path(st.session_state["mechanism_csv"]), "Relatório de mecanismo"
+            )
+        _display_log(workspace)
+
+    with tabs[5]:
+        st.subheader("Treinamento ML")
+        features_csv = st.session_state.get("features_csv")
+        cols = st.columns(3)
+        if cols[0].button("Treinar classificador", disabled=not features_csv):
+            with st.spinner("Treinando classificador..."):
+                result = orchestrator.run_ml_train_cls(
+                    Path(features_csv), preset, workspace
+                )
+            st.session_state["ml_cls"] = {
+                "outdir": str(result["outdir"]),
+                "model_card": result["model_card"],
+            }
+            st.success(f"Artefatos do classificador em {result['outdir']}")
+        if cols[1].button("Treinar regressor", disabled=not features_csv):
+            with st.spinner("Treinando regressor..."):
+                result = orchestrator.run_ml_train_reg(
+                    Path(features_csv), preset, workspace
+                )
+            st.session_state["ml_reg"] = {
+                "outdir": str(result["outdir"]),
+                "model_card": result["model_card"],
+            }
+            st.success(f"Artefatos do regressor em {result['outdir']}")
+        if cols[2].button(
+            "Prever", disabled=not features_csv or not st.session_state.get("ml_cls")
+        ):
+            model_info = st.session_state.get("ml_cls")
+            if model_info:
+                model_path = Path(model_info["outdir"]) / "classifier.joblib"
+                with st.spinner("Gerando predições..."):
+                    output = orchestrator.run_ml_predict(
+                        Path(features_csv), model_path, preset, workspace
+                    )
+                st.session_state["predictions_csv"] = str(output)
+                st.success(f"Predições salvas em {output}")
+        if st.session_state.get("ml_cls"):
+            st.subheader("Métricas — Classificação")
+            st.json(st.session_state["ml_cls"].get("model_card", {}))
+        if st.session_state.get("ml_reg"):
+            st.subheader("Métricas — Regressão")
+            st.json(st.session_state["ml_reg"].get("model_card", {}))
+        if st.session_state.get("predictions_csv"):
+            _show_dataframe(Path(st.session_state["predictions_csv"]), "Predições")
+        _display_log(workspace)
+
+    with tabs[6]:
+        st.subheader("Export & Relatórios")
+        export_cfg = preset.setdefault("export", {})
+        theta_outputs = st.session_state.get("theta_outputs", {})
+        if theta_outputs:
+            export_cfg.setdefault("msc_csv", theta_outputs.get("msc_curve"))
+            export_cfg.setdefault("img_msc", theta_outputs.get("msc_plot"))
+        if st.session_state.get("features_csv"):
+            export_cfg.setdefault("features_csv", st.session_state.get("features_csv"))
+        if st.session_state.get("ml_cls"):
+            export_cfg.setdefault(
+                "metrics_json",
+                str(Path(st.session_state["ml_cls"]["outdir"]) / "model_card.json"),
+            )
+        if st.button("Gerar ZIP de artefatos"):
+            with st.spinner("Gerando relatório e pacote ZIP..."):
+                zip_path = orchestrator.build_report(workspace.path, preset, workspace)
+            st.session_state["export_zip"] = str(zip_path)
+            st.success(f"Pacote gerado em {zip_path}")
+        if (
+            st.session_state.get("export_zip")
+            and Path(st.session_state["export_zip"]).exists()
+        ):
+            zip_path = Path(st.session_state["export_zip"])
+            st.download_button(
+                "Baixar artefatos",
+                data=zip_path.read_bytes(),
+                file_name=zip_path.name,
+            )
+        _display_log(workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/ogum-ml-lite/ogum_lite/ui/__init__.py
+++ b/ogum-ml-lite/ogum_lite/ui/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for the interactive Ogum Lite frontends."""
+
+from .presets import load_presets, merge_presets, save_presets
+from .workspace import Workspace
+
+__all__ = [
+    "Workspace",
+    "load_presets",
+    "merge_presets",
+    "save_presets",
+]

--- a/ogum-ml-lite/ogum_lite/ui/orchestrator.py
+++ b/ogum-ml-lite/ogum_lite/ui/orchestrator.py
@@ -1,0 +1,421 @@
+"""Thin wrappers around the Ogum Lite CLI used by the UIs."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+from ..validators import validate_feature_df, validate_long_df
+from .workspace import Workspace
+
+CLI_MODULE = "ogum_lite.cli"
+
+
+def _format_list(values: Iterable[Any]) -> str:
+    return ",".join(str(item) for item in values)
+
+
+def _run_cli(
+    args: list[str], ws: Workspace, event: str, extra: dict | None = None
+) -> subprocess.CompletedProcess:
+    command = [sys.executable, "-m", CLI_MODULE, *args]
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = {
+        "command": command,
+        "stdout": completed.stdout[-4000:],
+        "stderr": completed.stderr[-4000:],
+    }
+    if extra:
+        payload.update(extra)
+    ws.log_event(event, payload)
+    return completed
+
+
+def _mapping_from_preset(cfg: dict[str, Any]) -> dict[str, Any]:
+    columns = cfg.get("columns", {})
+    return {
+        "sample_id": columns.get("group_col", "sample_id"),
+        "time_col": columns.get("t_col", "time_s"),
+        "temp_col": columns.get("temp_col", "temp_C"),
+        "y_col": columns.get("y_col", "rho_rel"),
+        "composition": columns.get("composition_col", "composition"),
+        "technique": columns.get("technique_col", "technique"),
+        "time_unit": columns.get("time_unit", "s"),
+        "temp_unit": columns.get("temp_unit", "C"),
+    }
+
+
+def run_prep(input_csv: Path, cfg: dict[str, Any], ws: Workspace) -> Path:
+    """Execute ``preprocess derive`` using CLI based on the preset."""
+
+    prep_cfg = cfg.get("prep", {})
+    mapping = prep_cfg.get("mapping") or _mapping_from_preset(cfg)
+    mapping_path = ws.resolve(prep_cfg.get("mapping_path", "cache/column_mapping.json"))
+    mapping_path.parent.mkdir(parents=True, exist_ok=True)
+    mapping_path.write_text(json.dumps(mapping, indent=2, ensure_ascii=False))
+
+    output_path = ws.resolve(prep_cfg.get("output", "prep/ensaios_prep.csv"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = [
+        "preprocess",
+        "derive",
+        "--input",
+        str(input_csv),
+        "--map",
+        str(mapping_path),
+        "--out",
+        str(output_path),
+    ]
+    for key in ("smooth", "window", "poly", "moving_k"):
+        if key in prep_cfg and prep_cfg[key] is not None:
+            args.extend([f"--{key.replace('_', '-')}", str(prep_cfg[key])])
+
+    _run_cli(args, ws, "preprocess.derive", {"output": str(output_path)})
+    return output_path
+
+
+def run_features(input_csv: Path, cfg: dict[str, Any], ws: Workspace) -> Path:
+    """Generate feature table via CLI ``features`` command."""
+
+    features_cfg = cfg.get("features", {})
+    msc_cfg = cfg.get("msc", {})
+    columns = cfg.get("columns", {})
+
+    output_path = ws.resolve(features_cfg.get("output", "features/features.csv"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    ea_values = msc_cfg.get("ea_kj") or []
+    if not ea_values:
+        raise ValueError("Preset must provide msc.ea_kj for feature generation")
+    args = [
+        "features",
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_path),
+    ]
+    args.extend(["--ea", _format_list(ea_values)])
+    args.extend(
+        [
+            "--group-col",
+            columns.get("group_col", "sample_id"),
+            "--time-column",
+            columns.get("t_col", "time_s"),
+            "--temperature-column",
+            columns.get("temp_col", "temp_C"),
+            "--y-column",
+            columns.get("y_col", "rho_rel"),
+        ]
+    )
+
+    _run_cli(args, ws, "features.legacy", {"output": str(output_path)})
+    return output_path
+
+
+def run_theta_msc(
+    input_csv: Path, cfg: dict[str, Any], ws: Workspace
+) -> dict[str, Any]:
+    """Compute θ(Ea) table and MSC artifacts."""
+
+    msc_cfg = cfg.get("msc", {})
+    columns = cfg.get("columns", {})
+    ea_values = msc_cfg.get("ea_kj", [])
+    if not ea_values:
+        raise ValueError("Preset must provide msc.ea_kj for θ/MSC computation")
+    outdir = ws.resolve(msc_cfg.get("outdir", "theta_msc"))
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    theta_args = [
+        "theta",
+        "--input",
+        str(input_csv),
+        "--ea",
+        _format_list(ea_values),
+        "--time-column",
+        columns.get("t_col", "time_s"),
+        "--temperature-column",
+        columns.get("temp_col", "temp_C"),
+        "--outdir",
+        str(outdir),
+    ]
+    _run_cli(theta_args, ws, "theta.compute", {"outdir": str(outdir)})
+
+    theta_table = outdir / "theta_table.csv"
+    theta_zip = outdir / "theta_curves.zip"
+    if theta_table.exists():
+        df = pd.read_csv(theta_table)
+        with zipfile.ZipFile(theta_zip, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            if "sample_id" in df.columns:
+                for sample_id, group in df.groupby("sample_id"):
+                    buffer = group.to_csv(index=False).encode("utf-8")
+                    zf.writestr(f"theta_{sample_id}.csv", buffer)
+            else:  # pragma: no cover - fallback for unexpected schema
+                zf.writestr("theta_table.csv", df.to_csv(index=False).encode("utf-8"))
+
+    msc_curve = outdir / "msc_curve.csv"
+    msc_png = outdir / "msc_plot.png"
+    msc_args = [
+        "msc",
+        "--input",
+        str(input_csv),
+        "--ea",
+        _format_list(ea_values),
+        "--metric",
+        msc_cfg.get("metric", "segmented"),
+        "--group-col",
+        columns.get("group_col", "sample_id"),
+        "--time-column",
+        columns.get("t_col", "time_s"),
+        "--temperature-column",
+        columns.get("temp_col", "temp_C"),
+        "--y-column",
+        columns.get("y_col", "rho_rel"),
+        "--csv",
+        str(msc_curve),
+        "--png",
+        str(msc_png),
+    ]
+    result = _run_cli(msc_args, ws, "msc.score", {"outdir": str(outdir)})
+
+    match = re.search(r"best_Ea_kJ_mol=([0-9.]+)", result.stdout)
+    best_ea = float(match.group(1)) if match else None
+
+    return {
+        "best_ea": best_ea,
+        "theta_table": theta_table,
+        "theta_zip": theta_zip,
+        "msc_curve": msc_curve,
+        "msc_plot": msc_png,
+    }
+
+
+def run_segmentation(input_csv: Path, cfg: dict[str, Any], ws: Workspace) -> Path:
+    """Execute CLI segmentation with preset options."""
+
+    seg_cfg = cfg.get("segmentation", {})
+    columns = cfg.get("columns", {})
+    output_path = ws.resolve(seg_cfg.get("output", "segments/segments.json"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = [
+        "segmentation",
+        "--input",
+        str(input_csv),
+        "--out",
+        str(output_path),
+        "--mode",
+        seg_cfg.get("mode", "fixed"),
+        "--group-col",
+        columns.get("group_col", "sample_id"),
+        "--time-column",
+        columns.get("t_col", "time_s"),
+        "--y-column",
+        columns.get("y_col", "rho_rel"),
+    ]
+    if seg_cfg.get("mode", "fixed") == "fixed" and seg_cfg.get("bounds"):
+        args.extend(["--thresholds", ",".join(seg_cfg.get("bounds", []))])
+    else:
+        if "segments" in seg_cfg:
+            args.extend(["--segments", str(seg_cfg["segments"])])
+        if "min_size" in seg_cfg:
+            args.extend(["--min-size", str(seg_cfg["min_size"])])
+
+    _run_cli(args, ws, "segmentation.run", {"output": str(output_path)})
+    return output_path
+
+
+def run_mechanism(theta_csv: Path, cfg: dict[str, Any], ws: Workspace) -> Path:
+    """Detect mechanism change based on θ(Ea) trajectories."""
+
+    mech_cfg = cfg.get("mechanism", {})
+    columns = cfg.get("columns", {})
+    output_path = ws.resolve(mech_cfg.get("output", "mechanism/mechanism.csv"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = [
+        "mechanism",
+        "--theta",
+        str(theta_csv),
+        "--out",
+        str(output_path),
+        "--group-col",
+        columns.get("group_col", "sample_id"),
+    ]
+    if "theta_column" in mech_cfg:
+        args.extend(["--theta-column", mech_cfg["theta_column"]])
+    if "y_column" in mech_cfg:
+        args.extend(["--y-column", mech_cfg["y_column"]])
+    if "segments" in mech_cfg:
+        args.extend(["--segments", str(mech_cfg["segments"])])
+    if "min_size" in mech_cfg:
+        args.extend(["--min-size", str(mech_cfg["min_size"])])
+    if "criterion" in mech_cfg:
+        args.extend(["--criterion", mech_cfg["criterion"]])
+    if "threshold" in mech_cfg:
+        args.extend(["--threshold", str(mech_cfg["threshold"])])
+    if "slope_delta" in mech_cfg:
+        args.extend(["--slope-delta", str(mech_cfg["slope_delta"])])
+
+    _run_cli(args, ws, "mechanism.run", {"output": str(output_path)})
+    return output_path
+
+
+def run_ml_train_cls(
+    features_csv: Path, cfg: dict[str, Any], ws: Workspace
+) -> dict[str, Any]:
+    """Train classification model via CLI ``ml train-cls``."""
+
+    ml_cfg = cfg.get("ml", {})
+    columns = cfg.get("columns", {})
+    outdir = ws.resolve(ml_cfg.get("cls_outdir", "ml/classifier"))
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    features = list(ml_cfg.get("features", []))
+    if not features:
+        raise ValueError("Preset must provide ml.features for classification training")
+
+    args = [
+        "ml",
+        "train-cls",
+        "--table",
+        str(features_csv),
+        "--target",
+        ml_cfg.get("cls_target", "technique"),
+        "--group-col",
+        columns.get("group_col", "sample_id"),
+        "--outdir",
+        str(outdir),
+    ]
+    args.extend(["--features", *features])
+
+    result = _run_cli(args, ws, "ml.train_cls", {"outdir": str(outdir)})
+    model_card = outdir / "model_card.json"
+    metrics = json.loads(model_card.read_text()) if model_card.exists() else {}
+    return {
+        "outdir": outdir,
+        "stdout": result.stdout,
+        "model_card": metrics,
+    }
+
+
+def run_ml_train_reg(
+    features_csv: Path, cfg: dict[str, Any], ws: Workspace
+) -> dict[str, Any]:
+    """Train regression model via CLI ``ml train-reg``."""
+
+    ml_cfg = cfg.get("ml", {})
+    columns = cfg.get("columns", {})
+    outdir = ws.resolve(ml_cfg.get("reg_outdir", "ml/regressor"))
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    features = list(ml_cfg.get("features", []))
+    if not features:
+        raise ValueError("Preset must provide ml.features for regression training")
+
+    args = [
+        "ml",
+        "train-reg",
+        "--table",
+        str(features_csv),
+        "--target",
+        ml_cfg.get("reg_target", "T90_C"),
+        "--group-col",
+        columns.get("group_col", "sample_id"),
+        "--outdir",
+        str(outdir),
+    ]
+    args.extend(["--features", *features])
+
+    result = _run_cli(args, ws, "ml.train_reg", {"outdir": str(outdir)})
+    model_card = outdir / "model_card.json"
+    metrics = json.loads(model_card.read_text()) if model_card.exists() else {}
+    return {
+        "outdir": outdir,
+        "stdout": result.stdout,
+        "model_card": metrics,
+    }
+
+
+def run_ml_predict(
+    features_csv: Path, model_path: Path, cfg: dict[str, Any], ws: Workspace
+) -> Path:
+    """Generate predictions from a stored model artifact."""
+
+    predict_cfg = cfg.get("ml", {})
+    output_path = ws.resolve(predict_cfg.get("predict_output", "ml/predictions.csv"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = [
+        "ml",
+        "predict",
+        "--table",
+        str(features_csv),
+        "--model",
+        str(model_path),
+        "--out",
+        str(output_path),
+    ]
+    _run_cli(args, ws, "ml.predict", {"output": str(output_path)})
+    return output_path
+
+
+def run_validation(input_csv: Path, cfg: dict[str, Any]) -> dict[str, Any]:
+    """Validate long-format datasets using the shared validators."""
+
+    columns = cfg.get("columns", {})
+    df = pd.read_csv(input_csv)
+    return validate_long_df(df, y_col=columns.get("y_col", "rho_rel"))
+
+
+def run_feature_validation(features_csv: Path) -> dict[str, Any]:
+    """Validate feature tables using the shared validators."""
+
+    df = pd.read_csv(features_csv)
+    return validate_feature_df(df)
+
+
+def build_report(artifacts_dir: Path, cfg: dict[str, Any], ws: Workspace) -> Path:
+    """Generate the consolidated XLSX report and bundle workspace outputs."""
+
+    export_cfg = cfg.get("export", {})
+    report_path = ws.resolve(export_cfg.get("report", "reports/ogum_report.xlsx"))
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = [
+        "export",
+        "xlsx",
+        "--out",
+        str(report_path),
+    ]
+    optional_flags = {
+        "msc": export_cfg.get("msc_csv"),
+        "features": export_cfg.get("features_csv"),
+        "metrics": export_cfg.get("metrics_json"),
+        "dataset": export_cfg.get("dataset_name"),
+        "notes": export_cfg.get("notes"),
+        "img-msc": export_cfg.get("img_msc"),
+        "img-cls": export_cfg.get("img_cls"),
+        "img-reg": export_cfg.get("img_reg"),
+    }
+    for flag, value in optional_flags.items():
+        if value:
+            args.extend([f"--{flag}", str(value)])
+
+    _run_cli(args, ws, "export.xlsx", {"report": str(report_path)})
+
+    zip_target = ws.resolve(export_cfg.get("zip", "exports/session_artifacts.zip"))
+    ws.zip_outputs(artifacts_dir, zip_target)
+    return zip_target

--- a/ogum-ml-lite/ogum_lite/ui/presets.py
+++ b/ogum-ml-lite/ogum_lite/ui/presets.py
@@ -1,0 +1,69 @@
+"""Preset management helpers for the Ogum Lite UI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+PresetDict = Dict[str, Any]
+
+
+def load_presets(path: Path) -> PresetDict:
+    """Load presets from a YAML file.
+
+    Parameters
+    ----------
+    path
+        Path to the YAML file.
+
+    Returns
+    -------
+    dict
+        Parsed preset dictionary. Returns an empty dictionary when the file
+        does not exist.
+    """
+
+    path = Path(path)
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text())
+    if data is None:
+        return {}
+    if not isinstance(data, dict):  # pragma: no cover - defensive
+        raise TypeError("Preset file must contain a mapping at the top level")
+    return data
+
+
+def save_presets(preset: PresetDict, path: Path) -> None:
+    """Persist a preset dictionary to disk as YAML."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(preset, sort_keys=False, allow_unicode=True))
+
+
+def merge_presets(base: PresetDict, override: PresetDict) -> PresetDict:
+    """Deep-merge two preset dictionaries.
+
+    ``override`` values take precedence over ``base``. Nested dictionaries are
+    merged recursively while other objects are replaced.
+    """
+
+    def _merge(a: Any, b: Any) -> Any:
+        if isinstance(a, dict) and isinstance(b, dict):
+            result: dict[str, Any] = {}
+            keys = set(a) | set(b)
+            for key in keys:
+                if key in a and key in b:
+                    result[key] = _merge(a[key], b[key])
+                elif key in a:
+                    result[key] = a[key]
+                else:
+                    result[key] = b[key]
+            return result
+        return b
+
+    merged = _merge(dict(base), dict(override)) if override else dict(base)
+    return merged

--- a/ogum-ml-lite/ogum_lite/ui/workspace.py
+++ b/ogum-ml-lite/ogum_lite/ui/workspace.py
@@ -1,0 +1,85 @@
+"""Workspace utilities used by the interactive applications."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class Workspace:
+    """Represent a sandboxed directory tree for a UI session."""
+
+    root: Path
+    log_name: str = "run_log.jsonl"
+    _root: Path = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        root = Path(self.root).expanduser().resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        self._root = root
+
+    @property
+    def path(self) -> Path:
+        """Return the root path for the workspace."""
+
+        return self._root
+
+    def resolve(self, path_like: str | Path) -> Path:
+        """Resolve ``path_like`` within the workspace boundary."""
+
+        candidate = (self._root / Path(path_like)).expanduser().resolve()
+        if not candidate.is_relative_to(self._root):  # pragma: no cover - safety
+            raise ValueError(f"Path {candidate} escapes workspace root {self._root}")
+        return candidate
+
+    def ensure_dirs(self, *paths: str | Path) -> None:
+        """Ensure that the provided directories exist."""
+
+        for item in paths:
+            directory = self.resolve(item)
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def log_event(self, event: str, payload: dict | None = None) -> None:
+        """Append an event to the JSONL provenance log."""
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            "payload": payload or {},
+        }
+        log_path = self.resolve(self.log_name)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    def zip_outputs(self, outdir: Path, zip_path: Path) -> Path:
+        """Zip the contents of ``outdir`` into ``zip_path``."""
+
+        source = self.resolve(outdir)
+        target = self.resolve(zip_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(target, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for file in sorted(source.rglob("*")):
+                if file.is_file():
+                    zf.write(file, arcname=file.relative_to(source))
+        return target
+
+    def iter_artifacts(self, patterns: Iterable[str] | None = None) -> list[Path]:
+        """Return a list of artifacts stored in the workspace.
+
+        Parameters
+        ----------
+        patterns
+            Optional glob patterns to filter the artifacts.
+        """
+
+        patterns = list(patterns or ["**/*"])
+        results: list[Path] = []
+        for pattern in patterns:
+            results.extend(sorted(self._root.glob(pattern)))
+        return [path for path in results if path.is_file()]

--- a/ogum-ml-lite/pyproject.toml
+++ b/ogum-ml-lite/pyproject.toml
@@ -17,11 +17,13 @@ dependencies = [
     "matplotlib",
     "joblib",
     "gradio",
+    "streamlit",
     "openpyxl",
     "pydantic",
     "fastapi",
     "uvicorn",
     "xlrd",
+    "pyyaml",
 ]
 
 classifiers = [

--- a/ogum-ml-lite/tests/test_presets.py
+++ b/ogum-ml-lite/tests/test_presets.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from ogum_lite.ui.presets import load_presets, merge_presets, save_presets
+
+
+def test_presets_roundtrip(tmp_path: Path) -> None:
+    preset = {
+        "columns": {"group_col": "sample_id", "t_col": "time_s"},
+        "msc": {"ea_kj": [200, 300]},
+    }
+    path = tmp_path / "preset.yaml"
+    save_presets(preset, path)
+
+    loaded = load_presets(path)
+    assert loaded == preset
+
+    override = {"msc": {"metric": "global"}, "columns": {"temp_col": "temp_C"}}
+    merged = merge_presets(preset, override)
+
+    assert merged["msc"]["ea_kj"] == [200, 300]
+    assert merged["msc"]["metric"] == "global"
+    assert merged["columns"]["temp_col"] == "temp_C"
+    # Ensure original preset remains unchanged
+    assert "metric" not in preset["msc"]

--- a/ogum-ml-lite/tests/test_workspace.py
+++ b/ogum-ml-lite/tests/test_workspace.py
@@ -1,0 +1,30 @@
+import json
+import zipfile
+from pathlib import Path
+
+from ogum_lite.ui.workspace import Workspace
+
+
+def test_workspace_zip_outputs(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "session")
+    data_dir = ws.resolve("outputs")
+    data_dir.mkdir(parents=True, exist_ok=True)
+    file_a = data_dir / "a.txt"
+    file_a.write_text("alpha", encoding="utf-8")
+    file_b = data_dir / "nested" / "b.txt"
+    file_b.parent.mkdir(parents=True, exist_ok=True)
+    file_b.write_text("bravo", encoding="utf-8")
+
+    log_payload = {"step": "test", "ok": True}
+    ws.log_event("unit-test", log_payload)
+    log_path = ws.resolve(ws.log_name)
+    assert log_path.exists()
+    entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert entry["event"] == "unit-test"
+
+    zip_path = ws.zip_outputs(data_dir, ws.resolve("exports/session.zip"))
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+        assert "a.txt" in names
+        assert "nested/b.txt" in names


### PR DESCRIPTION
## Summary
- add a multi-tab Streamlit dashboard and lightweight Gradio Blocks front-end that orchestrate the existing CLI to run the Ogum Lite pipeline end-to-end
- introduce UI helpers for presets, workspace management, and CLI orchestration together with a default preset bundle and updated documentation
- add targeted infrastructure tests for preset round-trips and workspace zipping while declaring the new Streamlit/PyYAML dependencies

## Testing
- `black app/streamlit_app.py app/gradio_app.py ogum_lite/ui/__init__.py ogum_lite/ui/presets.py ogum_lite/ui/workspace.py ogum_lite/ui/orchestrator.py tests/test_presets.py tests/test_workspace.py --check`
- `ruff check app/streamlit_app.py app/gradio_app.py ogum_lite/ui tests/test_presets.py tests/test_workspace.py`
- `pytest tests/test_presets.py tests/test_workspace.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d7ef558dc8832793df801790eee553