### PR TITLE
Add modular Streamlit frontend with services layer and i18n

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -30,10 +30,10 @@ de usar em Google Colab e pronto para integrações com pipelines de ML.
 - **Pronto para ML**: módulo `features` com engenharia global e stage-aware,
   integração com `theta_msc` e `ml_hooks` para pipelines supervisionados.
 
-## Frontend Alpha (Fase 7)
+## Frontend Evolutivo (Fase 8)
 
-Esta fase adiciona um frontend interativo completo para executar o pipeline
-Ogum Lite de ponta a ponta em dados reais.
+O frontend agora usa uma arquitetura modular com design system leve, theming
+dinâmico, i18n e camada de serviços compartilhada.
 
 ### Streamlit (painel principal)
 
@@ -41,33 +41,34 @@ Ogum Lite de ponta a ponta em dados reais.
 streamlit run app/streamlit_app.py
 ```
 
-O painel está organizado em abas que refletem o fluxo recomendado:
+- **Layout modular**: shell comum em `app/design/layout.py` com sidebar para
+  workspace/preset, header com toggle de tema e export, e páginas em
+  `app/pages/*.py`.
+- **Theming**: `app/design/theme.py` expõe `get_theme(dark)` para claro/escuro;
+  alternância em tempo real sem recarregar o app.
+- **i18n**: seletor de idioma (pt/en) alimenta `app/i18n/translate.py` com
+  catálogos JSON; textos respondem imediatamente à troca de locale.
+- **Services**: todas as ações orquestram a CLI via `app/services/run_cli.py`
+  (tenacity + logs + telemetria) reaproveitando `ogum_lite.ui.orchestrator`.
+- **UX**: toasts, validações, barras de progresso e previews foram integrados às
+  páginas de Prep, Features, θ/MSC, Segmentação, Mecanismo, ML e Export.
+- **Estado**: `app/services/state.py` centraliza `session_state`, workspace e
+  registro de artefatos; telemetria opcional (`OGUML_TELEMETRY=0` desliga).
 
-1. **Workspace & Presets** – escolha o diretório base da sessão, carregue/edite
-   presets YAML e acompanhe o log de proveniência (`run_log.jsonl`).
-2. **Data Prep & Validate** – faça upload de CSV longos, execute validação com
-   `validators.validate_long_df` e acione `preprocess derive` via CLI.
-3. **Features** – derive a tabela de features, valide-a e visualize as primeiras
-   linhas diretamente no app.
-4. **θ / MSC** – compute θ(Ea), gere o colapso MSC (CSV/PNG) e baixe o pacote
-   de curvas `theta_curves.zip`.
-5. **Segmentação & Mecanismo** – rode segmentação (fixed/data) e o relatório de
-   mudança de mecanismo (Blaine/n) reaproveitando os módulos centrais.
-6. **ML** – treine classificadores/regressores, inspeccione o `model_card.json`
-   e gere predições usando artefatos do workspace.
-7. **Export** – consolide um relatório XLSX (`export xlsx`) e baixe um ZIP com
-   todos os artefatos da sessão.
+#### Como estender com nova página
 
-O preset padrão fica em `app/presets.yaml` e pode ser salvo/mesclado via UI.
+1. Crie `app/pages/page_nova.py` com `render(translator: I18N) -> None`.
+2. Use componentes do design system (`card`, `alert`, `toolbar`) e serviços.
+3. Registre a página em `PAGES` dentro de `app/streamlit_app.py`.
 
-### Gradio (alternativa leve)
+### Gradio (fallback)
 
 ```bash
 python app/gradio_app.py
 ```
 
-O modo Gradio expõe um formulário compacto (upload → preset → executar) que
-orquestra os mesmos comandos CLI e disponibiliza o ZIP consolidado.
+Interface Blocks compacta que reutiliza `app/services/run_cli.py` para rodar o
+pipeline e gerar o ZIP com os artefatos do workspace.
 
 ## Instalação
 

--- a/ogum-ml-lite/app/__init__.py
+++ b/ogum-ml-lite/app/__init__.py
@@ -1,0 +1,1 @@
+"""Ogum-ML frontend package."""

--- a/ogum-ml-lite/app/design/components.py
+++ b/ogum-ml-lite/app/design/components.py
@@ -1,0 +1,98 @@
+"""Reusable Streamlit UI components used across the dashboard."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Sequence
+
+import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+
+from .theme import get_theme
+
+
+def card(title: str, body: Any, help: str | None = None) -> DeltaGenerator:
+    """Render a card container with consistent styling.
+
+    Parameters
+    ----------
+    title:
+        Card title rendered in bold text.
+    body:
+        Body content to render. Objects are passed directly to ``st.write``.
+    help:
+        Optional tooltip text appended to the title.
+
+    Returns
+    -------
+    streamlit.delta_generator.DeltaGenerator
+        Container reference so callers may append extra elements if needed.
+    """
+
+    theme = get_theme(st.session_state.get("dark_mode", False))
+    container = st.container()
+    with container:
+        st.markdown(
+            '<div style="'
+            f"background:{theme['colors']['surface']};"
+            f" padding:{theme['space']['md']}px;"
+            f" border-radius:{theme['radii']['md']}px;"
+            f" border:1px solid {theme['colors']['border']};"
+            '">',
+            unsafe_allow_html=True,
+        )
+        title_style = theme["typography"]["subtitle_size"]
+        title_html = (
+            "<div style='font-weight:600;font-size:" f"{title_style}'>" f"{title}</div>"
+        )
+        st.markdown(title_html, unsafe_allow_html=True)
+        if help:
+            st.caption(help)
+        st.write(body)
+        st.markdown("</div>", unsafe_allow_html=True)
+    return container
+
+
+def alert(kind: Literal["info", "success", "warn", "error"], text: str) -> None:
+    """Render a semantic alert with high-contrast colours.
+
+    Parameters
+    ----------
+    kind:
+        Alert type. Maps to Streamlit's status elements.
+    text:
+        Message to display.
+    """
+
+    mapping = {
+        "info": st.info,
+        "success": st.success,
+        "warn": st.warning,
+        "error": st.error,
+    }
+    mapping.get(kind, st.info)(text)
+
+
+def toolbar(actions: Sequence[tuple[str, str]]) -> str | None:
+    """Render a compact toolbar of buttons.
+
+    Parameters
+    ----------
+    actions:
+        Iterable of ``(label, callback_key)`` tuples. The callback key is stored
+        in ``st.session_state`` when the button is activated.
+
+    Returns
+    -------
+    str or None
+        The key corresponding to the pressed button during the current rerun.
+    """
+
+    if not actions:
+        return None
+
+    cols = st.columns(len(actions))
+    for idx, (label, key) in enumerate(actions):
+        if cols[idx].button(label, key=f"toolbar_{key}"):
+            st.session_state["toolbar_last_action"] = key
+            return key
+    return None

--- a/ogum-ml-lite/app/design/layout.py
+++ b/ogum-ml-lite/app/design/layout.py
@@ -1,0 +1,124 @@
+"""Layout primitives for rendering the Streamlit shell."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import state
+from .theme import get_theme
+
+
+def _apply_theme(dark: bool) -> None:
+    theme = get_theme(dark)
+    st.markdown(
+        f"""
+        <style>
+        body {{
+            background: {theme['colors']['background']};
+            color: {theme['colors']['text']};
+            font-family: {theme['typography']['family']};
+        }}
+        .stApp header {{ background: transparent; }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _render_sidebar(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    st.sidebar.header(translator.t("workspace.title"))
+    current_path = str(workspace.path)
+    new_path = st.sidebar.text_input(
+        translator.t("workspace.path_label"), value=current_path
+    )
+    if new_path and new_path != current_path:
+        state.set_workspace(Path(new_path))
+        st.sidebar.success(translator.t("messages.workspace_changed"))
+
+    uploaded = st.sidebar.file_uploader(
+        translator.t("workspace.load_file"), type=["yaml", "yml"]
+    )
+    if uploaded is not None:
+        text = uploaded.read().decode("utf-8")
+        state.set_preset_yaml(text)
+        state.get_preset()
+        st.sidebar.info(translator.t("messages.preset_applied"))
+
+    preset_yaml = st.sidebar.text_area(
+        translator.t("workspace.preset_label"),
+        value=state.get_preset_yaml(),
+        height=220,
+    )
+    if st.sidebar.button(translator.t("workspace.apply_preset")):
+        state.set_preset_yaml(preset_yaml)
+        state.get_preset()
+        st.sidebar.success(translator.t("messages.preset_applied"))
+    if st.sidebar.button(translator.t("workspace.restore")):
+        state.reset_preset()
+        st.sidebar.success(translator.t("messages.preset_applied"))
+
+    tail = state.workspace_log_tail()
+    if tail:
+        st.sidebar.caption(translator.t("workspace.log_tail"))
+        st.sidebar.code("\n".join(tail), language="json")
+
+    artifacts = state.list_artifacts()
+    if artifacts:
+        st.sidebar.caption("Artifacts")
+        for item in artifacts:
+            if item.path.exists() and item.path.is_file():
+                st.sidebar.download_button(
+                    label=f"{item.key}",
+                    data=item.path.read_bytes(),
+                    file_name=item.path.name,
+                    key=f"dl_{item.key}",
+                )
+    else:
+        st.sidebar.warning(translator.t("messages.no_artifacts"))
+
+
+def render_shell(page_fn: Callable[[], None], *, title: str, dark: bool) -> bool:
+    """Render the shared layout and execute ``page_fn`` within it.
+
+    Returns
+    -------
+    bool
+        ``True`` when the user requested a theme toggle.
+    """
+
+    state.ensure_session()
+    st.session_state.setdefault("i18n", I18N())
+    translator: I18N = st.session_state["i18n"]
+    st.session_state["dark_mode"] = dark
+    _apply_theme(dark)
+
+    _render_sidebar(translator)
+
+    st.title(title)
+    st.caption(translator.t("app.subtitle"))
+    cols = st.columns([6, 2, 2])
+    with cols[1]:
+        zip_artifact = state.get_artifact("session_zip")
+        if zip_artifact and zip_artifact.exists():
+            st.download_button(
+                label=translator.t("actions.export"),
+                data=zip_artifact.read_bytes(),
+                file_name=zip_artifact.name,
+                key="export_zip",
+            )
+    toggle = False
+    with cols[2]:
+        label = (
+            translator.t("actions.toggle_light")
+            if dark
+            else translator.t("actions.toggle_dark")
+        )
+        if st.button(label, key="toggle_theme"):
+            toggle = True
+    page_fn()
+    return toggle

--- a/ogum-ml-lite/app/design/theme.py
+++ b/ogum-ml-lite/app/design/theme.py
@@ -1,0 +1,67 @@
+"""Streamlit design system definitions for Ogum ML Lite."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+THEME: Dict[str, Any] = {
+    "colors": {
+        "background": "#f7f9fc",
+        "surface": "#ffffff",
+        "text": "#1d1f24",
+        "muted": "#5f6b7a",
+        "primary": "#2453A6",
+        "success": "#2d8a34",
+        "warning": "#b36b00",
+        "danger": "#ba1a1a",
+        "border": "#d5dbe5",
+    },
+    "typography": {
+        "family": "'Inter', 'Segoe UI', sans-serif",
+        "title_size": "1.75rem",
+        "subtitle_size": "1.1rem",
+        "body_size": "0.95rem",
+    },
+    "radii": {"sm": 4, "md": 8, "lg": 16},
+    "space": {"xs": 4, "sm": 6, "md": 12, "lg": 20, "xl": 32},
+    "dark": {
+        "colors": {
+            "background": "#12151c",
+            "surface": "#1b1f29",
+            "text": "#f4f6fb",
+            "muted": "#9aa4b5",
+            "primary": "#88a8f5",
+            "success": "#7dd48a",
+            "warning": "#ffd084",
+            "danger": "#ffb4ab",
+            "border": "#2c3240",
+        }
+    },
+}
+
+
+def get_theme(dark: bool = False) -> Dict[str, Any]:
+    """Return the merged theme for the given mode.
+
+    Parameters
+    ----------
+    dark:
+        Whether the dark palette should be used.
+
+    Returns
+    -------
+    dict
+        Deep copy of the theme dictionary, with the appropriate palette applied.
+    """
+
+    base = deepcopy({key: value for key, value in THEME.items() if key != "dark"})
+    if dark:
+        dark_overrides = THEME.get("dark", {})
+        for key, value in dark_overrides.items():
+            if isinstance(value, dict):
+                base.setdefault(key, {})
+                base[key].update(value)
+            else:  # pragma: no cover - future proofing
+                base[key] = deepcopy(value)
+    return base

--- a/ogum-ml-lite/app/gradio_app.py
+++ b/ogum-ml-lite/app/gradio_app.py
@@ -1,31 +1,30 @@
-"""Minimal Gradio interface for the Ogum ML Lite pipeline."""
+"""Gradio fallback interface reusing the service layer."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import gradio as gr
 import yaml
-from ogum_lite.ui import orchestrator
 from ogum_lite.ui.presets import load_presets, merge_presets
 from ogum_lite.ui.workspace import Workspace
+
+from app.services import run_cli
 
 APP_DIR = Path(__file__).parent
 DEFAULT_PRESET = APP_DIR / "presets.yaml"
 
 
-def _prepare_workspace() -> Workspace:
+def _workspace() -> Workspace:
     root = Path.cwd() / "artifacts" / "gradio-session"
     return Workspace(root)
 
 
-def _serialize_log(ws: Workspace) -> str:
+def _serialise_log(ws: Workspace) -> str:
     log_path = ws.resolve(ws.log_name)
     if not log_path.exists():
         return ""
-    tail = log_path.read_text(encoding="utf-8").strip().splitlines()[-8:]
-    return "\n".join(tail)
+    return "\n".join(log_path.read_text(encoding="utf-8").splitlines()[-12:])
 
 
 def run_pipeline(
@@ -34,58 +33,44 @@ def run_pipeline(
     if file is None:
         raise gr.Error("Envie um CSV longo para iniciar a pipeline.")
 
-    ws = _prepare_workspace()
+    ws = _workspace()
     preset = load_presets(DEFAULT_PRESET)
     if preset_yaml:
-        try:
-            override = yaml.safe_load(preset_yaml) or {}
-        except yaml.YAMLError as exc:  # pragma: no cover - defensive
-            raise gr.Error(f"Preset inválido: {exc}") from exc
+        override = yaml.safe_load(preset_yaml) or {}
         preset = merge_presets(preset, override)
+
     upload_path = ws.resolve("uploads") / Path(file.name).name
     upload_path.parent.mkdir(parents=True, exist_ok=True)
     upload_path.write_bytes(Path(file.name).read_bytes())
 
-    try:
-        prep_csv = orchestrator.run_prep(upload_path, preset, ws)
-        features_csv = orchestrator.run_features(prep_csv, preset, ws)
-        theta_outputs = orchestrator.run_theta_msc(prep_csv, preset, ws)
-        orchestrator.run_segmentation(prep_csv, preset, ws)
-        orchestrator.run_mechanism(Path(theta_outputs["theta_table"]), preset, ws)
-        orchestrator.run_ml_train_cls(features_csv, preset, ws)
-    except Exception as exc:  # pragma: no cover - UI surface
-        return f"Erro na pipeline: {exc}", None
+    prep_result = run_cli.run_prep(upload_path, preset, ws)
+    features_result = run_cli.run_features(prep_result.outputs["prep_csv"], preset, ws)
+    theta_result = run_cli.run_theta_msc(prep_result.outputs["prep_csv"], preset, ws)
+    run_cli.run_segmentation(prep_result.outputs["prep_csv"], preset, ws)
+    run_cli.run_mechanism(theta_result.outputs["theta_table"], preset, ws)
+    run_cli.run_ml_train_cls(features_result.outputs["features_csv"], preset, ws)
+    export_result = run_cli.export_report(ws.path, preset, ws)
 
-    zip_path = orchestrator.build_report(ws.path, preset, ws)
-    log_tail = _serialize_log(ws)
-    return log_tail, str(zip_path)
+    return _serialise_log(ws), str(export_result.outputs["zip"])
 
 
 def main() -> None:
     preset_text = (
         DEFAULT_PRESET.read_text(encoding="utf-8") if DEFAULT_PRESET.exists() else ""
     )
-
-    with gr.Blocks(title="Ogum ML Lite") as demo:
-        gr.Markdown("## Ogum ML Lite — Frontend Alpha (Gradio)")
+    with gr.Blocks(title="Ogum-ML") as demo:
+        gr.Markdown("## Ogum-ML — Pipeline Lite")
         with gr.Row():
             file_input = gr.File(
                 label="CSV longo", file_types=[".csv"], file_count="single"
             )
-            preset_input = gr.Textbox(
-                label="Preset YAML (opcional)",
-                lines=20,
-                value=preset_text,
-            )
+            preset_input = gr.Textbox(label="Preset YAML", lines=18, value=preset_text)
         run_btn = gr.Button("Executar pipeline")
         log_output = gr.Textbox(label="Log", lines=12)
         zip_output = gr.File(label="ZIP de artefatos")
 
-        def _callback(file: Any, preset: str) -> tuple[str, str | None]:
-            return run_pipeline(file, preset)
-
         run_btn.click(
-            _callback,
+            run_pipeline,
             inputs=[file_input, preset_input],
             outputs=[log_output, zip_output],
         )

--- a/ogum-ml-lite/app/i18n/locales/en.json
+++ b/ogum-ml-lite/app/i18n/locales/en.json
@@ -1,0 +1,43 @@
+{
+  "app": {
+    "title": "Ogum-ML Console",
+    "subtitle": "Evolutionary frontend"
+  },
+  "menu": {
+    "prep": "Prep & Validate",
+    "features": "Features",
+    "msc": "θ & MSC",
+    "segments": "Segmentation",
+    "mechanism": "Mechanism",
+    "ml": "ML Models",
+    "export": "Export"
+  },
+  "workspace": {
+    "title": "Workspace",
+    "path_label": "Session directory",
+    "preset_label": "Preset YAML",
+    "apply_preset": "Apply",
+    "restore": "Restore default",
+    "load_file": "Load preset",
+    "log_tail": "Recent events"
+  },
+  "actions": {
+    "validate": "Validate",
+    "run": "Run",
+    "download": "Download",
+    "refresh": "Refresh",
+    "train": "Train",
+    "predict": "Predict",
+    "export": "Export",
+    "toggle_dark": "Dark mode",
+    "toggle_light": "Light mode"
+  },
+  "messages": {
+    "ready": "[ok] ready",
+    "no_artifacts": "[warn] No artifacts available",
+    "workspace_changed": "[ok] Workspace updated",
+    "preset_applied": "[ok] Preset updated",
+    "validation_ok": "[ok] File validated",
+    "validation_failed": "[warn] Issues detected"
+  }
+}

--- a/ogum-ml-lite/app/i18n/locales/pt.json
+++ b/ogum-ml-lite/app/i18n/locales/pt.json
@@ -1,0 +1,43 @@
+{
+  "app": {
+    "title": "Ogum-ML Painel",
+    "subtitle": "Frontend evolutivo"
+  },
+  "menu": {
+    "prep": "Preparar & Validar",
+    "features": "Features",
+    "msc": "θ & MSC",
+    "segments": "Segmentação",
+    "mechanism": "Mecanismo",
+    "ml": "Modelos ML",
+    "export": "Exportar"
+  },
+  "workspace": {
+    "title": "Workspace",
+    "path_label": "Diretório da sessão",
+    "preset_label": "Preset YAML",
+    "apply_preset": "Aplicar",
+    "restore": "Restaurar padrão",
+    "load_file": "Carregar preset",
+    "log_tail": "Últimos eventos"
+  },
+  "actions": {
+    "validate": "Validar",
+    "run": "Executar",
+    "download": "Download",
+    "refresh": "Atualizar",
+    "train": "Treinar",
+    "predict": "Predizer",
+    "export": "Exportar",
+    "toggle_dark": "Modo escuro",
+    "toggle_light": "Modo claro"
+  },
+  "messages": {
+    "ready": "[ok] pronto",
+    "no_artifacts": "[warn] Sem artefatos disponíveis",
+    "workspace_changed": "[ok] Workspace atualizado",
+    "preset_applied": "[ok] Preset atualizado",
+    "validation_ok": "[ok] Arquivo validado",
+    "validation_failed": "[warn] Problemas encontrados"
+  }
+}

--- a/ogum-ml-lite/app/i18n/translate.py
+++ b/ogum-ml-lite/app/i18n/translate.py
@@ -1,0 +1,62 @@
+"""Lightweight i18n helper for the dashboard."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+import streamlit as st
+
+LOCALES_PATH = Path(__file__).with_suffix("").parent / "locales"
+DEFAULT_LOCALE = "pt"
+
+
+def _load_locale(locale: str) -> Mapping[str, Any]:
+    path = LOCALES_PATH / f"{locale}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Locale file missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=4)
+def _catalogue(locale: str) -> Mapping[str, Any]:
+    return _load_locale(locale)
+
+
+def _lookup(catalog: Mapping[str, Any], key: str) -> str | None:
+    cursor: Any = catalog
+    for piece in key.split("."):
+        if not isinstance(cursor, Mapping):
+            return None
+        cursor = cursor.get(piece)
+        if cursor is None:
+            return None
+    if isinstance(cursor, str):
+        return cursor
+    return None
+
+
+class I18N:
+    """Translation helper with session-aware locale selection."""
+
+    def __init__(self, locale: str = DEFAULT_LOCALE) -> None:
+        self.default_locale = locale
+
+    @property
+    def locale(self) -> str:
+        return st.session_state.get("locale", self.default_locale)
+
+    def t(self, key: str, **kwargs: Any) -> str:
+        """Return the translated text for ``key`` with optional formatting."""
+
+        for candidate in (self.locale, self.default_locale):
+            try:
+                catalog = _catalogue(candidate)
+            except FileNotFoundError:
+                continue
+            message = _lookup(catalog, key)
+            if message:
+                return message.format(**kwargs)
+        return key

--- a/ogum-ml-lite/app/pages/__init__.py
+++ b/ogum-ml-lite/app/pages/__init__.py
@@ -1,0 +1,21 @@
+"""Page registry for the Streamlit application."""
+
+from . import (
+    page_export,
+    page_features,
+    page_mechanism,
+    page_ml,
+    page_msc,
+    page_prep,
+    page_segments,
+)
+
+__all__ = [
+    "page_export",
+    "page_features",
+    "page_mechanism",
+    "page_ml",
+    "page_msc",
+    "page_prep",
+    "page_segments",
+]

--- a/ogum-ml-lite/app/pages/page_export.py
+++ b/ogum-ml-lite/app/pages/page_export.py
@@ -1,0 +1,41 @@
+"""Export workflow page."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state
+
+
+def render(translator: I18N) -> None:
+    """Render export utilities."""
+
+    st.subheader(translator.t("menu.export"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+
+    if st.button(translator.t("actions.export"), key="export_run"):
+        with st.spinner("Gerando artefatos..."):
+            result = run_cli.export_report(workspace.path, preset, workspace)
+        for key, path in result.outputs.items():
+            state.register_artifact(f"export_{key}", path, description="export")
+        state.register_artifact("session_zip", result.outputs["zip"], description="zip")
+        st.toast(translator.t("messages.ready"))
+
+    report = state.get_artifact("export_report")
+    if report and report.exists():
+        st.download_button(
+            label=f"XLSX · {report.name}",
+            data=report.read_bytes(),
+            file_name=report.name,
+            key="report_dl",
+        )
+    zip_path = state.get_artifact("session_zip")
+    if zip_path and zip_path.exists():
+        st.download_button(
+            label=f"ZIP · {zip_path.name}",
+            data=zip_path.read_bytes(),
+            file_name=zip_path.name,
+            key="zip_dl",
+        )

--- a/ogum-ml-lite/app/pages/page_features.py
+++ b/ogum-ml-lite/app/pages/page_features.py
@@ -1,0 +1,46 @@
+"""Feature engineering Streamlit page."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state, validators
+
+
+def render(translator: I18N) -> None:
+    """Render the feature engineering workflow."""
+
+    st.subheader(translator.t("menu.features"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    run_cols = st.columns(2)
+    if run_cols[0].button(translator.t("actions.run"), key="features_run"):
+        with st.spinner("Extraindo features..."):
+            result = run_cli.run_features(prep_csv, preset, workspace)
+        features_csv = result.outputs["features_csv"]
+        state.register_artifact("features_csv", features_csv, description="features")
+        st.toast(translator.t("messages.ready"))
+
+    features_csv = state.get_artifact("features_csv")
+    if features_csv and features_csv.exists():
+        if run_cols[1].button(
+            translator.t("actions.validate"), key="features_validate"
+        ):
+            summary = validators.validate_features(features_csv)
+            if summary.ok:
+                st.toast(translator.t("messages.validation_ok"))
+            for issue in summary.issues:
+                st.warning(issue)
+
+        st.caption(f"Preview · {features_csv.name}")
+        st.dataframe(pd.read_csv(features_csv).head(25))
+    else:
+        st.info(translator.t("messages.no_artifacts"))

--- a/ogum-ml-lite/app/pages/page_mechanism.py
+++ b/ogum-ml-lite/app/pages/page_mechanism.py
@@ -1,0 +1,40 @@
+"""Mechanism analysis page."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state
+
+
+def render(translator: I18N) -> None:
+    """Render mechanism detection workflow."""
+
+    st.subheader(translator.t("menu.mechanism"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+
+    theta_table = state.get_artifact("theta_table")
+    if theta_table is None:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    if st.button(translator.t("actions.run"), key="mechanism_run"):
+        with st.spinner("Calculando mecanismo..."):
+            result = run_cli.run_mechanism(theta_table, preset, workspace)
+        mech_path = result.outputs["mechanism"]
+        state.register_artifact("mechanism", mech_path, description="mechanism")
+        st.toast(translator.t("messages.ready"))
+
+    mech_path = state.get_artifact("mechanism")
+    if mech_path and mech_path.exists():
+        df = pd.read_csv(mech_path)
+        st.dataframe(df.head(50))
+        st.download_button(
+            label=f"CSV · {mech_path.name}",
+            data=mech_path.read_bytes(),
+            file_name=mech_path.name,
+            key="mechanism_dl",
+        )

--- a/ogum-ml-lite/app/pages/page_ml.py
+++ b/ogum-ml-lite/app/pages/page_ml.py
@@ -1,0 +1,97 @@
+"""Machine learning orchestration page."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state
+
+
+def _load_card(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:  # pragma: no cover - defensive
+            return {}
+    return {}
+
+
+def _list_models(workspace_root: Path) -> list[Path]:
+    return sorted(workspace_root.rglob("*.joblib"))
+
+
+def render(translator: I18N) -> None:
+    """Render ML training and inference workflow."""
+
+    st.subheader(translator.t("menu.ml"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    features_csv = state.get_artifact("features_csv")
+    if features_csv is None:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    tab_train_cls, tab_train_reg, tab_predict = st.tabs(
+        ["Train CLS", "Train REG", "Predict"]
+    )
+
+    with tab_train_cls:
+        if st.button(translator.t("actions.train"), key="ml_train_cls"):
+            with st.spinner("Treinando classificador..."):
+                result = run_cli.run_ml_train_cls(features_csv, preset, workspace)
+            outdir = result.outputs["outdir"]
+            state.register_artifact("ml_cls", outdir, description="ml_cls")
+            state.register_artifact(
+                "ml_cls_card", result.outputs["model_card"], description="ml_cls"
+            )
+            st.toast(translator.t("messages.ready"))
+            card = _load_card(result.outputs["model_card"])
+            if card:
+                st.json(card)
+
+    with tab_train_reg:
+        if st.button(translator.t("actions.train"), key="ml_train_reg"):
+            with st.spinner("Treinando regressor..."):
+                result = run_cli.run_ml_train_reg(features_csv, preset, workspace)
+            outdir = result.outputs["outdir"]
+            state.register_artifact("ml_reg", outdir, description="ml_reg")
+            state.register_artifact(
+                "ml_reg_card", result.outputs["model_card"], description="ml_reg"
+            )
+            st.toast(translator.t("messages.ready"))
+            card = _load_card(result.outputs["model_card"])
+            if card:
+                st.json(card)
+
+    with tab_predict:
+        models = _list_models(workspace.path)
+        option = st.selectbox(
+            "Modelo",
+            options=[str(path) for path in models],
+            format_func=lambda value: Path(value).name,
+            key="ml_model_pick",
+        )
+        if option and st.button(translator.t("actions.predict"), key="ml_predict"):
+            with st.spinner("Gerando predições..."):
+                result = run_cli.run_ml_predict(
+                    features_csv, Path(option), preset, workspace
+                )
+            predictions = result.outputs["predictions"]
+            state.register_artifact(
+                "predictions", predictions, description="predictions"
+            )
+            st.toast(translator.t("messages.ready"))
+        predictions = state.get_artifact("predictions")
+        if predictions and predictions.exists():
+            st.dataframe(pd.read_csv(predictions).head(25))
+            st.download_button(
+                label=f"CSV · {predictions.name}",
+                data=predictions.read_bytes(),
+                file_name=predictions.name,
+                key="predictions_dl",
+            )

--- a/ogum-ml-lite/app/pages/page_msc.py
+++ b/ogum-ml-lite/app/pages/page_msc.py
@@ -1,0 +1,51 @@
+"""θ and MSC visualisation page."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state
+
+
+def render(translator: I18N) -> None:
+    """Render θ/MSC orchestration."""
+
+    st.subheader(translator.t("menu.msc"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    if st.button(translator.t("actions.run"), key="msc_run"):
+        with st.spinner("Executando θ/MSC..."):
+            result = run_cli.run_theta_msc(prep_csv, preset, workspace)
+        for key, path in result.outputs.items():
+            state.register_artifact(key, path, description="msc")
+        st.toast(translator.t("messages.ready"))
+
+    curve_path = state.get_artifact("msc_curve")
+    plot_path = state.get_artifact("msc_plot")
+    if curve_path and curve_path.exists():
+        df = pd.read_csv(curve_path)
+        if {"Ea_kJ", "metric"}.issubset(df.columns):
+            figure = px.line(df, x="Ea_kJ", y="metric", markers=True)
+            st.plotly_chart(figure, use_container_width=True)
+        st.download_button(
+            label=f"CSV · {curve_path.name}",
+            data=curve_path.read_bytes(),
+            file_name=curve_path.name,
+            key="msc_csv_dl",
+        )
+    if plot_path and plot_path.exists():
+        st.download_button(
+            label=f"PNG · {plot_path.name}",
+            data=plot_path.read_bytes(),
+            file_name=plot_path.name,
+            key="msc_png_dl",
+        )

--- a/ogum-ml-lite/app/pages/page_prep.py
+++ b/ogum-ml-lite/app/pages/page_prep.py
@@ -1,0 +1,66 @@
+"""Prep and validation Streamlit page."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state, validators
+
+
+def _list_csv(workspace_path: Path) -> list[Path]:
+    uploads = workspace_path / "uploads"
+    if not uploads.exists():
+        return []
+    return sorted(uploads.glob("*.csv"))
+
+
+def render(translator: I18N) -> None:
+    """Render the preparation workflow."""
+
+    st.subheader(translator.t("menu.prep"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+
+    uploaded = st.file_uploader("CSV", type=["csv"], key="prep_upload")
+    if uploaded is not None:
+        target = state.persist_upload(uploaded)
+        st.toast(f"[ok] {uploaded.name} → {target.name}")
+
+    csv_files = _list_csv(workspace.path)
+    if not csv_files:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    option = st.selectbox(
+        "Dataset",
+        options=[str(path) for path in csv_files],
+        format_func=lambda value: Path(value).name,
+        key="prep_dataset",
+    )
+    if not option:
+        return
+
+    selected = Path(option)
+    cols = st.columns(2)
+    if cols[0].button(translator.t("actions.validate"), key="prep_validate"):
+        summary = validators.validate_long(selected)
+        if summary.ok:
+            st.toast(translator.t("messages.validation_ok"))
+        for issue in summary.issues:
+            st.warning(issue)
+
+    if cols[1].button(translator.t("actions.run"), key="prep_run"):
+        with st.spinner("Rodando preprocess..."):
+            result = run_cli.run_prep(selected, preset, workspace)
+        prep_csv = result.outputs["prep_csv"]
+        state.register_artifact("prep_csv", prep_csv, description="prep")
+        st.toast(translator.t("messages.ready"))
+
+    preview_target = state.get_artifact("prep_csv") or selected
+    if preview_target.exists():
+        st.caption(f"Preview · {preview_target.name}")
+        st.dataframe(pd.read_csv(preview_target).head(30))

--- a/ogum-ml-lite/app/pages/page_segments.py
+++ b/ogum-ml-lite/app/pages/page_segments.py
@@ -1,0 +1,45 @@
+"""Segmentation workflow page."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import streamlit as st
+
+from ..i18n.translate import I18N
+from ..services import run_cli, state
+
+
+def render(translator: I18N) -> None:
+    """Render the segmentation pipeline."""
+
+    st.subheader(translator.t("menu.segments"))
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None:
+        st.info(translator.t("messages.no_artifacts"))
+        return
+
+    if st.button(translator.t("actions.run"), key="segmentation_run"):
+        with st.spinner("Segmentando..."):
+            result = run_cli.run_segmentation(prep_csv, preset, workspace)
+        segments_path = result.outputs["segments"]
+        state.register_artifact("segments", segments_path, description="segments")
+        st.toast(translator.t("messages.ready"))
+
+    segments_path = state.get_artifact("segments")
+    if segments_path and segments_path.exists():
+        try:
+            data = json.loads(segments_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            st.code(segments_path.read_text(encoding="utf-8"), language="json")
+        else:
+            st.dataframe(pd.DataFrame(data))
+        st.download_button(
+            label=f"JSON · {segments_path.name}",
+            data=segments_path.read_bytes(),
+            file_name=segments_path.name,
+            key="segments_dl",
+        )

--- a/ogum-ml-lite/app/presets.yaml
+++ b/ogum-ml-lite/app/presets.yaml
@@ -14,12 +14,15 @@ msc:
   ea_kj: [200, 300, 400]
   metric: segmented
   outdir: theta_msc
+  img_msc: theta_msc/msc_plot.png
 segmentation:
   mode: fixed
   bounds:
     - "0.55,0.70"
     - "0.70,0.90"
   output: segments/segments.json
+mechanism:
+  output: mechanism/mechanism.csv
 ml:
   features:
     - heating_rate_med_C_per_s
@@ -32,6 +35,7 @@ ml:
   reg_target: T90_C
   cls_outdir: ml/classifier
   reg_outdir: ml/regressor
+  predict_output: ml/predictions.csv
 export:
   outdir: artifacts/session-{{timestamp}}
   report: reports/ogum_report.xlsx

--- a/ogum-ml-lite/app/services/__init__.py
+++ b/ogum-ml-lite/app/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service namespace for the frontend."""
+
+__all__ = ["run_cli", "state", "telemetry", "validators"]

--- a/ogum-ml-lite/app/services/run_cli.py
+++ b/ogum-ml-lite/app/services/run_cli.py
@@ -1,0 +1,248 @@
+"""Service layer bridging the UI with the Ogum Lite CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping
+
+from ogum_lite.ui import orchestrator
+from ogum_lite.ui.workspace import Workspace
+from tenacity import RetryError, retry, stop_after_attempt, wait_fixed
+
+from . import telemetry
+
+
+@dataclass(slots=True)
+class RunResult:
+    """Container for CLI execution outputs."""
+
+    stdout: str
+    stderr: str
+    outputs: dict[str, Path]
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(0.4))
+def _execute(command: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def _log_tail(workspace: Workspace, lines: int = 12) -> str:
+    log_path = workspace.resolve(workspace.log_name)
+    if not log_path.exists():
+        return ""
+    return "\n".join(log_path.read_text(encoding="utf-8").splitlines()[-lines:])
+
+
+def _wrap_orchestrator(
+    func: Callable[..., Any],
+    workspace: Workspace,
+    event: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    @retry(stop=stop_after_attempt(2), wait=wait_fixed(0.2))
+    def _call() -> Any:
+        return func(*args, **kwargs)
+
+    try:
+        result = _call()
+    except Exception as exc:
+        telemetry.log_event(workspace, f"{event}.error", {"message": str(exc)})
+        raise
+    telemetry.log_event(workspace, event, {})
+    return result
+
+
+def run_prep(
+    input_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    output = _wrap_orchestrator(
+        orchestrator.run_prep, workspace, "prep", input_csv, preset, workspace
+    )
+    return RunResult(
+        stdout=_log_tail(workspace),
+        stderr="",
+        outputs={"prep_csv": Path(output)},
+    )
+
+
+def run_features(
+    prep_csv: Path,
+    preset: Mapping[str, Any],
+    workspace: Workspace,
+    *,
+    use_prep: bool = True,
+) -> RunResult:
+    csv = prep_csv
+    if not use_prep:
+        csv = Path(preset.get("features", {}).get("input", prep_csv))
+    output = _wrap_orchestrator(
+        orchestrator.run_features, workspace, "features", csv, preset, workspace
+    )
+    return RunResult(
+        stdout=_log_tail(workspace),
+        stderr="",
+        outputs={"features_csv": Path(output)},
+    )
+
+
+def run_theta_msc(
+    prep_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    payload: Dict[str, Any] = _wrap_orchestrator(
+        orchestrator.run_theta_msc, workspace, "theta_msc", prep_csv, preset, workspace
+    )
+    outputs = {
+        "theta_table": Path(payload["theta_table"]),
+        "theta_zip": Path(payload["theta_zip"]),
+        "msc_curve": Path(payload["msc_curve"]),
+        "msc_plot": Path(payload["msc_plot"]),
+    }
+    if payload.get("best_ea") is not None:
+        telemetry.log_event(
+            workspace, "theta_msc.best_ea", {"best_ea": payload["best_ea"]}
+        )
+    return RunResult(stdout=_log_tail(workspace), stderr="", outputs=outputs)
+
+
+def run_segmentation(
+    prep_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    path = _wrap_orchestrator(
+        orchestrator.run_segmentation,
+        workspace,
+        "segmentation",
+        prep_csv,
+        preset,
+        workspace,
+    )
+    return RunResult(
+        stdout=_log_tail(workspace),
+        stderr="",
+        outputs={"segments": Path(path)},
+    )
+
+
+def run_mechanism(
+    theta_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    path = _wrap_orchestrator(
+        orchestrator.run_mechanism, workspace, "mechanism", theta_csv, preset, workspace
+    )
+    return RunResult(
+        stdout=_log_tail(workspace),
+        stderr="",
+        outputs={"mechanism": Path(path)},
+    )
+
+
+def run_ml_train_cls(
+    features_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    payload: Dict[str, Any] = _wrap_orchestrator(
+        orchestrator.run_ml_train_cls,
+        workspace,
+        "ml_train_cls",
+        features_csv,
+        preset,
+        workspace,
+    )
+    outdir = Path(payload["outdir"])
+    outputs = {"outdir": outdir, "model_card": outdir / "model_card.json"}
+    return RunResult(
+        stdout=payload.get("stdout", _log_tail(workspace)),
+        stderr="",
+        outputs=outputs,
+    )
+
+
+def run_ml_train_reg(
+    features_csv: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    payload: Dict[str, Any] = _wrap_orchestrator(
+        orchestrator.run_ml_train_reg,
+        workspace,
+        "ml_train_reg",
+        features_csv,
+        preset,
+        workspace,
+    )
+    outdir = Path(payload["outdir"])
+    outputs = {"outdir": outdir, "model_card": outdir / "model_card.json"}
+    return RunResult(
+        stdout=payload.get("stdout", _log_tail(workspace)),
+        stderr="",
+        outputs=outputs,
+    )
+
+
+def run_ml_predict(
+    features_csv: Path,
+    model_path: Path,
+    preset: Mapping[str, Any],
+    workspace: Workspace,
+) -> RunResult:
+    prediction = _wrap_orchestrator(
+        orchestrator.run_ml_predict,
+        workspace,
+        "ml_predict",
+        features_csv,
+        model_path,
+        preset,
+        workspace,
+    )
+    return RunResult(
+        stdout=_log_tail(workspace),
+        stderr="",
+        outputs={"predictions": Path(prediction)},
+    )
+
+
+def export_report(
+    artifacts_dir: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    zip_path = _wrap_orchestrator(
+        orchestrator.build_report, workspace, "export", artifacts_dir, preset, workspace
+    )
+    export_cfg = preset.get("export", {})
+    report_path = workspace.resolve(
+        export_cfg.get("report", "reports/ogum_report.xlsx")
+    )
+    outputs = {"zip": Path(zip_path), "report": report_path}
+    return RunResult(stdout=_log_tail(workspace), stderr="", outputs=outputs)
+
+
+def export_onnx(
+    model_dir: Path, preset: Mapping[str, Any], workspace: Workspace
+) -> RunResult:
+    ml_cfg = preset.get("ml", {})
+    feature_list = [str(item) for item in ml_cfg.get("features", [])]
+    model_path = model_dir / ml_cfg.get("onnx_model", "model.onnx")
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        orchestrator.CLI_MODULE,
+        "export",
+        "onnx",
+        "--model",
+        str(model_dir / ml_cfg.get("onnx_source", "model.joblib")),
+        "--out",
+        str(model_path),
+    ]
+    if feature_list:
+        command.extend(["--features", *feature_list])
+    try:
+        completed = _execute(command)
+    except RetryError as exc:  # pragma: no cover - defensive surface
+        telemetry.log_event(workspace, "export_onnx.error", {"error": str(exc)})
+        raise
+    telemetry.log_event(workspace, "export_onnx", {"model": str(model_path)})
+    return RunResult(
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        outputs={"onnx": model_path},
+    )

--- a/ogum-ml-lite/app/services/state.py
+++ b/ogum-ml-lite/app/services/state.py
@@ -1,0 +1,174 @@
+"""Session state helpers for the Streamlit dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import streamlit as st
+import yaml
+from ogum_lite.ui.presets import load_presets, merge_presets
+from ogum_lite.ui.workspace import Workspace
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PRESET_PATH = APP_ROOT / "presets.yaml"
+DEFAULT_WORKSPACE = Path.cwd() / "artifacts" / "ui-session"
+
+
+@dataclass(slots=True)
+class Artifact:
+    """Metadata for generated artifacts."""
+
+    key: str
+    path: Path
+    description: str | None = None
+
+
+def ensure_session(locale: str = "pt") -> None:
+    """Initialise Streamlit session state with sane defaults."""
+
+    st.session_state.setdefault("locale", locale)
+    st.session_state.setdefault("dark_mode", False)
+    st.session_state.setdefault("workspace_root", str(DEFAULT_WORKSPACE))
+    st.session_state.setdefault("artifacts", {})
+    st.session_state.setdefault(
+        "preset_yaml", DEFAULT_PRESET_PATH.read_text(encoding="utf-8")
+    )
+
+
+def get_workspace() -> Workspace:
+    """Return the active workspace object."""
+
+    root = Path(st.session_state.get("workspace_root", str(DEFAULT_WORKSPACE)))
+    workspace = st.session_state.get("workspace")
+    if isinstance(workspace, Workspace) and workspace.path == root:
+        return workspace
+    workspace = Workspace(root)
+    st.session_state["workspace"] = workspace
+    return workspace
+
+
+def set_workspace(root: Path) -> Workspace:
+    """Persist a new workspace path and rebuild the object."""
+
+    st.session_state["workspace_root"] = str(root)
+    workspace = Workspace(root)
+    st.session_state["workspace"] = workspace
+    return workspace
+
+
+def _load_preset_from_state() -> dict[str, Any]:
+    yaml_text = st.session_state.get("preset_yaml")
+    if not yaml_text:
+        return load_presets(DEFAULT_PRESET_PATH)
+    try:
+        parsed = yaml.safe_load(yaml_text) or {}
+    except yaml.YAMLError:
+        return load_presets(DEFAULT_PRESET_PATH)
+    base = load_presets(DEFAULT_PRESET_PATH)
+    return merge_presets(base, parsed)
+
+
+def get_preset() -> dict[str, Any]:
+    """Return the active preset merging overrides when necessary."""
+
+    preset = st.session_state.get("preset")
+    if isinstance(preset, dict):
+        return preset
+    preset = _load_preset_from_state()
+    st.session_state["preset"] = preset
+    return preset
+
+
+def set_preset_yaml(text: str) -> None:
+    """Update the YAML preset override in session state."""
+
+    st.session_state["preset_yaml"] = text
+    st.session_state.pop("preset", None)
+
+
+def get_preset_yaml() -> str:
+    """Return the current YAML override for the preset."""
+
+    return st.session_state.get(
+        "preset_yaml", DEFAULT_PRESET_PATH.read_text(encoding="utf-8")
+    )
+
+
+def load_preset_file(path: Path) -> dict[str, Any]:
+    """Load a preset from disk and update the override."""
+
+    preset = load_presets(path)
+    base = _load_preset_from_state()
+    merged = merge_presets(base, preset)
+    st.session_state["preset_yaml"] = yaml.safe_dump(
+        merged, sort_keys=False, allow_unicode=True
+    )
+    st.session_state["preset"] = merged
+    return merged
+
+
+def reset_preset() -> dict[str, Any]:
+    """Restore the default preset bundled with the application."""
+
+    text = DEFAULT_PRESET_PATH.read_text(encoding="utf-8")
+    st.session_state["preset_yaml"] = text
+    st.session_state.pop("preset", None)
+    return get_preset()
+
+
+def persist_upload(upload, *, subdir: str = "uploads") -> Path:
+    """Persist an uploaded file inside the workspace."""
+
+    workspace = get_workspace()
+    uploads_dir = workspace.resolve(subdir)
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    target = uploads_dir / upload.name
+    with target.open("wb") as handle:
+        handle.write(upload.getbuffer())
+    register_artifact(upload.name, target, description="upload")
+    return target
+
+
+def register_artifact(key: str, path: Path, description: str | None = None) -> None:
+    """Register an artifact path in session state."""
+
+    artifacts: Dict[str, Any] = st.session_state.setdefault("artifacts", {})
+    artifacts[key] = {"path": str(path), "description": description}
+    st.session_state["artifacts"] = artifacts
+
+
+def get_artifact(key: str) -> Path | None:
+    """Retrieve a previously registered artifact."""
+
+    artifacts: Dict[str, Any] = st.session_state.get("artifacts", {})
+    info = artifacts.get(key)
+    if not info:
+        return None
+    return Path(info["path"])
+
+
+def list_artifacts() -> list[Artifact]:
+    """Return a list of registered artifacts."""
+
+    artifacts: Dict[str, Any] = st.session_state.get("artifacts", {})
+    return [
+        Artifact(
+            key=key,
+            path=Path(payload["path"]),
+            description=payload.get("description"),
+        )
+        for key, payload in artifacts.items()
+    ]
+
+
+def workspace_log_tail(lines: int = 8) -> list[str]:
+    """Return the tail of the workspace log file."""
+
+    workspace = get_workspace()
+    log_path = workspace.resolve(workspace.log_name)
+    if not log_path.exists():
+        return []
+    tail = log_path.read_text(encoding="utf-8").splitlines()[-lines:]
+    return tail

--- a/ogum-ml-lite/app/services/telemetry.py
+++ b/ogum-ml-lite/app/services/telemetry.py
@@ -1,0 +1,34 @@
+"""Telemetry helpers for dashboard interactions."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from ogum_lite.ui.workspace import Workspace
+
+
+def _enabled() -> bool:
+    return os.getenv("OGUML_TELEMETRY", "1") not in {"0", "false", "False"}
+
+
+def log_event(
+    workspace: Workspace, event: str, payload: Mapping[str, Any] | None = None
+) -> None:
+    """Append a telemetry event to ``run_log.jsonl`` when enabled."""
+
+    if not _enabled():
+        return
+
+    data = {
+        "event": event,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+    if payload:
+        data.update(dict(payload))
+    log_path = workspace.resolve("run_log.jsonl")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data, ensure_ascii=False) + "\n")

--- a/ogum-ml-lite/app/services/validators.py
+++ b/ogum-ml-lite/app/services/validators.py
@@ -1,0 +1,44 @@
+"""Validation helpers bridging CLI validators to UX messages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+from ogum_lite.validators import validate_feature_df, validate_long_df
+
+
+@dataclass(slots=True)
+class ValidationSummary:
+    """Structured validation result for display."""
+
+    ok: bool
+    issues: list[str]
+
+
+def _format_issues(issues: Iterable[str]) -> list[str]:
+    return [f"[warn] {issue}" for issue in issues]
+
+
+def validate_long(path: Path, *, y_col: str = "rho_rel") -> ValidationSummary:
+    """Validate a long-format CSV file using the shared validators."""
+
+    df = pd.read_csv(path)
+    result: dict[str, Any] = validate_long_df(df, y_col=y_col)
+    return ValidationSummary(
+        ok=bool(result.get("ok", False)),
+        issues=_format_issues(result.get("issues", [])),
+    )
+
+
+def validate_features(path: Path) -> ValidationSummary:
+    """Validate the engineered features CSV file."""
+
+    df = pd.read_csv(path)
+    result: dict[str, Any] = validate_feature_df(df)
+    return ValidationSummary(
+        ok=bool(result.get("ok", False)),
+        issues=_format_issues(result.get("issues", [])),
+    )

--- a/ogum-ml-lite/app/streamlit_app.py
+++ b/ogum-ml-lite/app/streamlit_app.py
@@ -1,376 +1,71 @@
-"""Ogum ML Lite Streamlit dashboard."""
+"""Main entry point for the Streamlit dashboard."""
 
 from __future__ import annotations
 
-import json
-from datetime import datetime
-from pathlib import Path
-from typing import Any
+from typing import Callable
 
-import pandas as pd
 import streamlit as st
-import yaml
-from ogum_lite.ui import orchestrator
-from ogum_lite.ui.presets import load_presets, merge_presets, save_presets
-from ogum_lite.ui.workspace import Workspace
 
-APP_DIR = Path(__file__).parent
-DEFAULT_PRESET_PATH = APP_DIR / "presets.yaml"
+from app.design.layout import render_shell
+from app.i18n.translate import I18N
+from app.pages import (
+    page_export,
+    page_features,
+    page_mechanism,
+    page_ml,
+    page_msc,
+    page_prep,
+    page_segments,
+)
+from app.services import state
+
+PAGES: dict[str, tuple[str, Callable[[I18N], None]]] = {
+    "prep": ("menu.prep", page_prep.render),
+    "features": ("menu.features", page_features.render),
+    "msc": ("menu.msc", page_msc.render),
+    "segments": ("menu.segments", page_segments.render),
+    "mechanism": ("menu.mechanism", page_mechanism.render),
+    "ml": ("menu.ml", page_ml.render),
+    "export": ("menu.export", page_export.render),
+}
 
 
-def _load_default_preset() -> dict[str, Any]:
-    if "preset" in st.session_state:
-        return st.session_state["preset"]
-    preset = load_presets(DEFAULT_PRESET_PATH)
-    st.session_state["preset"] = preset
-    st.session_state["preset_yaml"] = yaml.safe_dump(
-        preset, sort_keys=False, allow_unicode=True
+def _select_page(translator: I18N) -> str:
+    options = list(PAGES.keys())
+    selected = st.sidebar.radio(
+        "Menu",
+        options=options,
+        format_func=lambda key: translator.t(PAGES[key][0]),
+        key="main_menu",
     )
-    return preset
+    return selected
 
 
-def _get_workspace() -> Workspace:
-    root_text = st.session_state.get("workspace_root")
-    if not root_text:
-        default_root = Path.cwd() / "artifacts" / "ui-session"
-        st.session_state["workspace_root"] = str(default_root)
-        root_text = str(default_root)
-    workspace = Workspace(Path(root_text))
-    st.session_state["workspace"] = workspace
-    return workspace
-
-
-def _display_log(ws: Workspace) -> None:
-    log_path = ws.resolve(ws.log_name)
-    if not log_path.exists():
-        return
-    tail = log_path.read_text(encoding="utf-8").strip().splitlines()[-5:]
-    st.caption("Últimos eventos")
-    for line in tail:
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
-            st.code(line)
-            continue
-        st.code(json.dumps(entry, indent=2, ensure_ascii=False))
-
-
-def _persist_uploaded(file, ws: Workspace) -> Path:
-    uploads_dir = ws.resolve("uploads")
-    uploads_dir.mkdir(parents=True, exist_ok=True)
-    target = uploads_dir / file.name
-    with target.open("wb") as handle:
-        handle.write(file.getbuffer())
-    return target
-
-
-def _yaml_editor(preset: dict[str, Any], ws: Workspace) -> dict[str, Any]:
-    st.subheader("Preset manager")
-    uploaded = st.file_uploader(
-        "Carregar preset YAML", type=["yml", "yaml"], key="preset_upload"
-    )
-    if uploaded is not None:
-        loaded = yaml.safe_load(uploaded.read()) or {}
-        merged = merge_presets(preset, loaded)
-        st.session_state["preset"] = merged
-        st.session_state["preset_yaml"] = yaml.safe_dump(
-            merged, sort_keys=False, allow_unicode=True
-        )
-        st.success("Preset carregado e mesclado com sucesso.")
-        preset = merged
-
-    preset_yaml = st.text_area(
-        "Preset YAML",
-        value=st.session_state.get(
-            "preset_yaml", yaml.safe_dump(preset, sort_keys=False, allow_unicode=True)
-        ),
-        height=360,
-    )
-    cols = st.columns(3)
-    if cols[0].button("Aplicar preset"):
-        try:
-            loaded = yaml.safe_load(preset_yaml) or {}
-        except yaml.YAMLError as exc:
-            st.error(f"Erro ao interpretar YAML: {exc}")
-        else:
-            st.session_state["preset"] = loaded
-            st.session_state["preset_yaml"] = yaml.safe_dump(
-                loaded, sort_keys=False, allow_unicode=True
-            )
-            preset = loaded
-            st.success("Preset atualizado.")
-    if cols[1].button("Restaurar padrão"):
-        fresh = load_presets(DEFAULT_PRESET_PATH)
-        st.session_state["preset"] = fresh
-        st.session_state["preset_yaml"] = yaml.safe_dump(
-            fresh, sort_keys=False, allow_unicode=True
-        )
-        preset = fresh
-        st.info("Preset padrão restaurado.")
-    if cols[2].button("Salvar preset no workspace"):
-        target = _timestamped_preset_path(ws)
-        save_presets(preset, target)
-        st.success(f"Preset salvo em {target}")
-    return preset
-
-
-def _timestamped_preset_path(ws: Workspace) -> Path:
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    return ws.resolve(f"presets/preset-{timestamp}.yaml")
-
-
-def _show_dataframe(path: Path, caption: str, rows: int = 20) -> None:
-    if not path or not Path(path).exists():
-        return
-    df = pd.read_csv(path)
-    st.caption(caption)
-    st.dataframe(df.head(rows))
+def _select_locale() -> str:
+    return st.sidebar.selectbox("Idioma", options=["pt", "en"], key="locale_select")
 
 
 def main() -> None:
-    st.set_page_config(page_title="Ogum ML Lite", layout="wide")
-    st.title("Ogum ML Lite — Frontend Alpha")
+    st.set_page_config(page_title="Ogum-ML", layout="wide")
+    state.ensure_session()
+    translator: I18N = st.session_state.setdefault("i18n", I18N())
 
-    preset = _load_default_preset()
-    workspace = _get_workspace()
+    locale = _select_locale()
+    st.session_state["locale"] = locale
+    selected_page = _select_page(translator)
 
-    tabs = st.tabs(
-        [
-            "Workspace & Presets",
-            "Data Prep & Validate",
-            "Features",
-            "θ / MSC",
-            "Segmentação & Mecanismo",
-            "ML",
-            "Export",
-        ]
-    )
+    dark_mode = st.session_state.get("dark_mode", False)
 
-    with tabs[0]:
-        st.subheader("Workspace")
-        root_input = st.text_input(
-            "Diretório base da sessão", value=st.session_state["workspace_root"]
-        )
-        if root_input and root_input != st.session_state["workspace_root"]:
-            st.session_state["workspace_root"] = root_input
-            workspace = _get_workspace()
-        st.caption(f"Workspace ativo: {workspace.path}")
-        preset = _yaml_editor(preset, workspace)
-        _display_log(workspace)
+    def _page_runner() -> None:
+        translator = st.session_state["i18n"]
+        _, page_fn = PAGES[selected_page]
+        page_fn(translator)
 
-    with tabs[1]:
-        st.subheader("Data Prep & Validação")
-        uploaded = st.file_uploader("Upload CSV longo", type=["csv"], key="long_upload")
-        if uploaded is not None:
-            input_path = _persist_uploaded(uploaded, workspace)
-            st.session_state["input_csv"] = str(input_path)
-            st.success(f"Arquivo salvo em {input_path}")
-        input_default = st.session_state.get("input_csv", "")
-        input_path_text = st.text_input(
-            "ou informe caminho existente", value=input_default
-        )
-        if input_path_text:
-            st.session_state["input_csv"] = input_path_text
-        input_csv = st.session_state.get("input_csv")
-
-        cols = st.columns(3)
-        if cols[0].button("Validar long", disabled=not input_csv):
-            with st.spinner("Validando dados longos..."):
-                result = orchestrator.run_validation(Path(input_csv), preset)
-            st.session_state["validation_long"] = result
-            st.json(result)
-        if cols[1].button("Pré-processar", disabled=not input_csv):
-            with st.spinner("Executando preprocess derive..."):
-                prep_csv = orchestrator.run_prep(Path(input_csv), preset, workspace)
-            st.session_state["prep_csv"] = str(prep_csv)
-            st.success(f"Derivadas salvas em {prep_csv}")
-        if cols[2].button("Recarregar preset base"):
-            preset = _load_default_preset()
-            st.info("Preset padrão recarregado para esta sessão.")
-        _display_log(workspace)
-
-    with tabs[2]:
-        st.subheader("Features")
-        prep_csv = st.session_state.get("prep_csv") or st.session_state.get("input_csv")
-        st.text_input(
-            "Arquivo base para features", value=prep_csv or "", key="features_input"
-        )
-        features_input = st.session_state.get("features_input")
-        cols = st.columns(2)
-        if cols[0].button("Gerar features", disabled=not features_input):
-            with st.spinner("Gerando tabela de features..."):
-                features_csv = orchestrator.run_features(
-                    Path(features_input), preset, workspace
-                )
-            st.session_state["features_csv"] = str(features_csv)
-            st.success(f"Tabela de features salva em {features_csv}")
-        if cols[1].button(
-            "Validar features", disabled=not st.session_state.get("features_csv")
-        ):
-            with st.spinner("Validando tabela de features..."):
-                report = orchestrator.run_feature_validation(
-                    Path(st.session_state["features_csv"])
-                )
-            st.session_state["validation_features"] = report
-            st.json(report)
-        if st.session_state.get("features_csv"):
-            _show_dataframe(
-                Path(st.session_state["features_csv"]), "Prévia das features"
-            )
-        _display_log(workspace)
-
-    with tabs[3]:
-        st.subheader("θ(Ea) & MSC")
-        base_csv = st.session_state.get("prep_csv") or st.session_state.get("input_csv")
-        if st.button("Rodar θ/MSC", disabled=not base_csv):
-            with st.spinner("Calculando θ(Ea) e MSC..."):
-                outputs = orchestrator.run_theta_msc(Path(base_csv), preset, workspace)
-            serialized: dict[str, Any] = {}
-            for key, value in outputs.items():
-                if isinstance(value, Path):
-                    serialized[key] = str(value)
-                else:
-                    serialized[key] = value
-            st.session_state["theta_outputs"] = serialized
-            st.success(f"Melhor Ea: {outputs['best_ea']}")
-        outputs = st.session_state.get("theta_outputs")
-        if outputs:
-            st.metric("Ea ótimo (kJ/mol)", outputs.get("best_ea"))
-            theta_table = outputs.get("theta_table")
-            if theta_table and Path(theta_table).exists():
-                _show_dataframe(Path(theta_table), "Tabela θ(Ea)")
-            msc_plot = outputs.get("msc_plot")
-            if msc_plot and Path(msc_plot).exists():
-                st.image(msc_plot, caption="Master Sintering Curve")
-            msc_curve = outputs.get("msc_curve")
-            if msc_curve and Path(msc_curve).exists():
-                st.download_button(
-                    "Baixar MSC CSV",
-                    data=Path(msc_curve).read_bytes(),
-                    file_name=Path(msc_curve).name,
-                )
-            theta_zip = outputs.get("theta_zip")
-            if theta_zip and Path(theta_zip).exists():
-                st.download_button(
-                    "Baixar θ(Ea) ZIP",
-                    data=Path(theta_zip).read_bytes(),
-                    file_name=Path(theta_zip).name,
-                )
-        _display_log(workspace)
-
-    with tabs[4]:
-        st.subheader("Segmentação & Mecanismo")
-        base_csv = st.session_state.get("prep_csv")
-        theta_table = None
-        if st.session_state.get("theta_outputs"):
-            theta_table = st.session_state["theta_outputs"].get("theta_table")
-        cols = st.columns(2)
-        if cols[0].button("Segmentação", disabled=not base_csv):
-            with st.spinner("Executando segmentação..."):
-                segments = orchestrator.run_segmentation(
-                    Path(base_csv), preset, workspace
-                )
-            st.session_state["segments_json"] = str(segments)
-            st.success(f"Segmentos salvos em {segments}")
-        if cols[1].button("Detectar mecanismo", disabled=not theta_table):
-            with st.spinner("Detectando mudança de mecanismo..."):
-                mechanism = orchestrator.run_mechanism(
-                    Path(theta_table), preset, workspace
-                )
-            st.session_state["mechanism_csv"] = str(mechanism)
-            st.success(f"Relatório salvo em {mechanism}")
-        if (
-            st.session_state.get("segments_json")
-            and Path(st.session_state["segments_json"]).exists()
-        ):
-            data = json.loads(Path(st.session_state["segments_json"]).read_text())
-            st.json(data)
-        if (
-            st.session_state.get("mechanism_csv")
-            and Path(st.session_state["mechanism_csv"]).exists()
-        ):
-            _show_dataframe(
-                Path(st.session_state["mechanism_csv"]), "Relatório de mecanismo"
-            )
-        _display_log(workspace)
-
-    with tabs[5]:
-        st.subheader("Treinamento ML")
-        features_csv = st.session_state.get("features_csv")
-        cols = st.columns(3)
-        if cols[0].button("Treinar classificador", disabled=not features_csv):
-            with st.spinner("Treinando classificador..."):
-                result = orchestrator.run_ml_train_cls(
-                    Path(features_csv), preset, workspace
-                )
-            st.session_state["ml_cls"] = {
-                "outdir": str(result["outdir"]),
-                "model_card": result["model_card"],
-            }
-            st.success(f"Artefatos do classificador em {result['outdir']}")
-        if cols[1].button("Treinar regressor", disabled=not features_csv):
-            with st.spinner("Treinando regressor..."):
-                result = orchestrator.run_ml_train_reg(
-                    Path(features_csv), preset, workspace
-                )
-            st.session_state["ml_reg"] = {
-                "outdir": str(result["outdir"]),
-                "model_card": result["model_card"],
-            }
-            st.success(f"Artefatos do regressor em {result['outdir']}")
-        if cols[2].button(
-            "Prever", disabled=not features_csv or not st.session_state.get("ml_cls")
-        ):
-            model_info = st.session_state.get("ml_cls")
-            if model_info:
-                model_path = Path(model_info["outdir"]) / "classifier.joblib"
-                with st.spinner("Gerando predições..."):
-                    output = orchestrator.run_ml_predict(
-                        Path(features_csv), model_path, preset, workspace
-                    )
-                st.session_state["predictions_csv"] = str(output)
-                st.success(f"Predições salvas em {output}")
-        if st.session_state.get("ml_cls"):
-            st.subheader("Métricas — Classificação")
-            st.json(st.session_state["ml_cls"].get("model_card", {}))
-        if st.session_state.get("ml_reg"):
-            st.subheader("Métricas — Regressão")
-            st.json(st.session_state["ml_reg"].get("model_card", {}))
-        if st.session_state.get("predictions_csv"):
-            _show_dataframe(Path(st.session_state["predictions_csv"]), "Predições")
-        _display_log(workspace)
-
-    with tabs[6]:
-        st.subheader("Export & Relatórios")
-        export_cfg = preset.setdefault("export", {})
-        theta_outputs = st.session_state.get("theta_outputs", {})
-        if theta_outputs:
-            export_cfg.setdefault("msc_csv", theta_outputs.get("msc_curve"))
-            export_cfg.setdefault("img_msc", theta_outputs.get("msc_plot"))
-        if st.session_state.get("features_csv"):
-            export_cfg.setdefault("features_csv", st.session_state.get("features_csv"))
-        if st.session_state.get("ml_cls"):
-            export_cfg.setdefault(
-                "metrics_json",
-                str(Path(st.session_state["ml_cls"]["outdir"]) / "model_card.json"),
-            )
-        if st.button("Gerar ZIP de artefatos"):
-            with st.spinner("Gerando relatório e pacote ZIP..."):
-                zip_path = orchestrator.build_report(workspace.path, preset, workspace)
-            st.session_state["export_zip"] = str(zip_path)
-            st.success(f"Pacote gerado em {zip_path}")
-        if (
-            st.session_state.get("export_zip")
-            and Path(st.session_state["export_zip"]).exists()
-        ):
-            zip_path = Path(st.session_state["export_zip"])
-            st.download_button(
-                "Baixar artefatos",
-                data=zip_path.read_bytes(),
-                file_name=zip_path.name,
-            )
-        _display_log(workspace)
+    toggle = render_shell(_page_runner, title=translator.t("app.title"), dark=dark_mode)
+    if toggle:
+        st.session_state["dark_mode"] = not dark_mode
+        st.experimental_rerun()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual run
     main()

--- a/ogum-ml-lite/ogum_lite/blaine.py
+++ b/ogum-ml-lite/ogum_lite/blaine.py
@@ -45,7 +45,9 @@ class BlaineResult:
         }
 
 
-def _linearise_blaine(time_s: np.ndarray, y: np.ndarray) -> tuple[float, float, float, float]:
+def _linearise_blaine(
+    time_s: np.ndarray, y: np.ndarray
+) -> tuple[float, float, float, float]:
     mask = (time_s > 0) & (y > 0) & (y < 1)
     if mask.sum() < 2:
         return (float("nan"),) * 4

--- a/ogum-ml-lite/ogum_lite/cli.py
+++ b/ogum-ml-lite/ogum_lite/cli.py
@@ -53,8 +53,8 @@ from .reports import (
     plot_regression_scatter,
     render_html_report,
 )
-from .stages import DEFAULT_STAGES
 from .segmentation import segment_dataframe
+from .stages import DEFAULT_STAGES
 from .theta_msc import OgumLite, score_activation_energies
 from .validators import validate_feature_df, validate_long_df
 
@@ -2118,7 +2118,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser_msc.set_defaults(func=cmd_msc)
 
-    parser_maps = subparsers.add_parser("maps", help="Gerar heatmaps de Blaine/segmentos")
+    parser_maps = subparsers.add_parser(
+        "maps", help="Gerar heatmaps de Blaine/segmentos"
+    )
     parser_maps.add_argument(
         "--input",
         type=Path,

--- a/ogum-ml-lite/ogum_lite/features.py
+++ b/ogum-ml-lite/ogum_lite/features.py
@@ -239,7 +239,9 @@ def segment_feature_table(
         y_col=y_col,
     )
 
-    feature_map: dict[str | int | float, dict[str, float | int | str]] = defaultdict(dict)
+    feature_map: dict[str | int | float, dict[str, float | int | str]] = defaultdict(
+        dict
+    )
 
     for segment, blaine in zip(segments, blaine_results):
         sample_key = segment.sample_id
@@ -445,7 +447,9 @@ def build_feature_store(
         y_col=y_col,
     )
 
-    thresholds = segment_thresholds if segment_thresholds is not None else (0.55, 0.70, 0.90)
+    thresholds = (
+        segment_thresholds if segment_thresholds is not None else (0.55, 0.70, 0.90)
+    )
     segment_table = segment_feature_table(
         derived,
         method=segment_method,

--- a/ogum-ml-lite/ogum_lite/mechanism.py
+++ b/ogum-ml-lite/ogum_lite/mechanism.py
@@ -129,7 +129,9 @@ def detect_mechanism_change(
             )
             continue
 
-        base_model = fit_piecewise_linear(theta_values, densification, 1, min_size=min_size)
+        base_model = fit_piecewise_linear(
+            theta_values, densification, 1, min_size=min_size
+        )
         if base_model is None:
             records.append(
                 {
@@ -191,12 +193,16 @@ def detect_mechanism_change(
                 "n_segments": best_model.n_segments,
                 "criterion": best_model.criterion,
                 "baseline_criterion": best_model.baseline_criterion,
-                "breakpoint_theta": best_model.breakpoint_theta
-                if best_model.breakpoint_theta is not None
-                else float("nan"),
-                "breakpoint_densification": best_model.breakpoint_densification
-                if best_model.breakpoint_densification is not None
-                else float("nan"),
+                "breakpoint_theta": (
+                    best_model.breakpoint_theta
+                    if best_model.breakpoint_theta is not None
+                    else float("nan")
+                ),
+                "breakpoint_densification": (
+                    best_model.breakpoint_densification
+                    if best_model.breakpoint_densification is not None
+                    else float("nan")
+                ),
             }
         )
 

--- a/ogum-ml-lite/ogum_lite/reports.py
+++ b/ogum-ml-lite/ogum_lite/reports.py
@@ -126,9 +126,7 @@ def render_html_report(outdir: Path, context: dict, figures: dict[str, bytes]) -
     if isinstance(segments_summary, dict):
         segments_summary_html = "<ul>" + _dict_to_html_list(segments_summary) + "</ul>"
     elif isinstance(segments_summary, list):
-        items = "".join(
-            f"<li>{item}</li>" for item in segments_summary
-        )
+        items = "".join(f"<li>{item}</li>" for item in segments_summary)
         segments_summary_html = f"<ul>{items}</ul>"
 
     segments_table_html = _table_to_html(segments_table)

--- a/ogum-ml-lite/ogum_lite/segmentation.py
+++ b/ogum-ml-lite/ogum_lite/segmentation.py
@@ -90,11 +90,15 @@ def compute_information_criterion(
         # Guard against log(0) when the fit is perfect
         sse = 1e-12
     mse = sse / float(n_points)
-    penalty = 2 * n_parameters if criterion == "aic" else n_parameters * np.log(n_points)
+    penalty = (
+        2 * n_parameters if criterion == "aic" else n_parameters * np.log(n_points)
+    )
     return n_points * float(np.log(mse)) + penalty
 
 
-def _linear_stats(x: np.ndarray, y: np.ndarray, start: int, end: int) -> LinearSegmentStats:
+def _linear_stats(
+    x: np.ndarray, y: np.ndarray, start: int, end: int
+) -> LinearSegmentStats:
     segment_x = x[start:end]
     segment_y = y[start:end]
     if segment_x.size < 2:
@@ -129,7 +133,9 @@ def _linear_stats(x: np.ndarray, y: np.ndarray, start: int, end: int) -> LinearS
     )
 
 
-def _iter_endpoints(n_points: int, n_segments: int, min_size: int) -> Iterable[list[int]]:
+def _iter_endpoints(
+    n_points: int, n_segments: int, min_size: int
+) -> Iterable[list[int]]:
     if n_segments <= 0:
         raise ValueError("n_segments must be positive")
     if min_size <= 0:
@@ -263,7 +269,9 @@ def segment_group(
     if method == "fixed":
         raw_segments = segment_fixed(time, y, thresholds=thresholds)
     elif method == "data":
-        raw_segments = segment_data_driven(time, y, n_segments=n_segments, min_size=min_size)
+        raw_segments = segment_data_driven(
+            time, y, n_segments=n_segments, min_size=min_size
+        )
     else:
         raise ValueError("method must be 'fixed' or 'data'")
 

--- a/ogum-ml-lite/pyproject.toml
+++ b/ogum-ml-lite/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "joblib",
     "gradio",
     "streamlit",
+    "plotly",
+    "tenacity",
+    "typing_extensions",
     "openpyxl",
     "pydantic",
     "fastapi",
@@ -47,7 +50,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["ogum_lite"]
+include = ["ogum_lite", "app"]
 
 [tool.black]
 line-length = 88

--- a/ogum-ml-lite/tests/test_api.py
+++ b/ogum-ml-lite/tests/test_api.py
@@ -1,7 +1,5 @@
 from fastapi.testclient import TestClient
-
 from ogum_lite.api.main import app
-
 
 client = TestClient(app)
 

--- a/ogum-ml-lite/tests/test_blaine.py
+++ b/ogum-ml-lite/tests/test_blaine.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from ogum_lite.blaine import fit_blaine_by_segments, fit_blaine_segment
 from ogum_lite.segmentation import Segment
 

--- a/ogum-ml-lite/tests/test_design.py
+++ b/ogum-ml-lite/tests/test_design.py
@@ -1,0 +1,26 @@
+"""Design system smoke tests."""
+
+from __future__ import annotations
+
+from app.design.theme import get_theme
+from streamlit.testing.v1 import AppTest
+
+
+def test_theme_variants() -> None:
+    light = get_theme(False)
+    dark = get_theme(True)
+    assert light["colors"]["background"] != dark["colors"]["background"]
+    assert light["colors"]["primary"]
+
+
+def test_components_smoke() -> None:
+    def app() -> None:
+        from app.design.components import alert, card, toolbar
+
+        card("Title", "Body")
+        alert("info", "Testing")
+        toolbar([("Action", "act")])
+
+    test = AppTest.from_function(app)
+    result = test.run()
+    assert not result.exception

--- a/ogum-ml-lite/tests/test_frontend.py
+++ b/ogum-ml-lite/tests/test_frontend.py
@@ -1,0 +1,10 @@
+"""Tests for frontend wiring."""
+
+from __future__ import annotations
+
+from app import streamlit_app
+
+
+def test_pages_registry_contains_expected_entries() -> None:
+    expected = {"prep", "features", "msc", "segments", "mechanism", "ml", "export"}
+    assert expected.issubset(streamlit_app.PAGES.keys())

--- a/ogum-ml-lite/tests/test_i18n.py
+++ b/ogum-ml-lite/tests/test_i18n.py
@@ -1,0 +1,22 @@
+"""Tests for the i18n helper."""
+
+from __future__ import annotations
+
+import streamlit as st
+from app.i18n.translate import I18N
+
+
+def test_translation_lookup_and_fallback() -> None:
+    st.session_state.clear()
+    st.session_state["locale"] = "en"
+    helper = I18N()
+    assert helper.t("actions.run") == "Run"
+    st.session_state["locale"] = "xx"
+    assert helper.t("actions.run") == "Executar"
+
+
+def test_interpolation() -> None:
+    st.session_state.clear()
+    helper = I18N("pt")
+    st.session_state["locale"] = "en"
+    assert helper.t("messages.ready") == "[ok] ready"

--- a/ogum-ml-lite/tests/test_maps.py
+++ b/ogum-ml-lite/tests/test_maps.py
@@ -1,5 +1,4 @@
 import pandas as pd
-
 from ogum_lite.maps import prepare_segment_heatmap, render_segment_heatmap
 
 
@@ -23,5 +22,3 @@ def test_prepare_segment_heatmap_extracts_blaine_columns(tmp_path) -> None:
     output.write_bytes(png_bytes)
     assert output.exists()
     assert output.stat().st_size > 0
-
-

--- a/ogum-ml-lite/tests/test_mechanism.py
+++ b/ogum-ml-lite/tests/test_mechanism.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from ogum_lite.mechanism import detect_mechanism_change
 
 

--- a/ogum-ml-lite/tests/test_segmentation.py
+++ b/ogum-ml-lite/tests/test_segmentation.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from ogum_lite.segmentation import segment_dataframe
 
 

--- a/ogum-ml-lite/tests/test_services.py
+++ b/ogum-ml-lite/tests/test_services.py
@@ -1,0 +1,37 @@
+"""Tests for the service orchestration layer."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from app.services import run_cli
+from ogum_lite.ui.workspace import Workspace
+
+
+def test_run_prep_wraps_orchestrator(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OGUML_TELEMETRY", "0")
+    ws = Workspace(tmp_path)
+
+    def fake_run_prep(input_csv: Path, preset: dict, workspace: Workspace) -> Path:
+        assert workspace is ws
+        return tmp_path / "prep.csv"
+
+    monkeypatch.setattr(run_cli.orchestrator, "run_prep", fake_run_prep)
+    result = run_cli.run_prep(tmp_path / "input.csv", {}, ws)
+    assert result.outputs["prep_csv"].name == "prep.csv"
+
+
+def test_export_onnx_invokes_cli(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OGUML_TELEMETRY", "0")
+    ws = Workspace(tmp_path)
+
+    def fake_execute(command: list[str]) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(run_cli, "_execute", fake_execute)
+    preset = {"ml": {"features": ["f1"], "onnx_source": "model.joblib"}}
+    (tmp_path / "model.joblib").write_bytes(b"binary")
+    result = run_cli.export_onnx(tmp_path, preset, ws)
+    assert result.stdout == "ok"
+    assert result.outputs["onnx"].suffix == ".onnx"


### PR DESCRIPTION
## Summary
- modularize the Streamlit dashboard into themed layout/components, localized text, and page modules that orchestrate the existing CLI
- add shared services for session state, telemetry, CLI execution, and validators plus a Gradio fallback and updated presets
- document the new frontend architecture and ship smoke tests covering i18n, design system, services, and page registry

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f8e6c40883278c207096c770d0e0