### PR TITLE
Add guided wizard UX, accessibility helpers, and translation lint

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -55,11 +55,26 @@ streamlit run app/streamlit_app.py
 - **Estado**: `app/services/state.py` centraliza `session_state`, workspace e
   registro de artefatos; telemetria opcional (`OGUML_TELEMETRY=0` desliga).
 
+### Modo guiado (Wizard)
+
+- Disponível no menu lateral como primeira opção (`Modo guiado`).
+- Bloqueia a navegação enquanto os artefatos obrigatórios não estiverem prontos e exibe toasts `[ok]/[warn]`.
+- Cada etapa reutiliza os serviços existentes (`run_cli`) com tooltips, descrições acessíveis e persistência em `session_state`.
+- Documentação completa de UX e microcópia em [`docs/DESIGN_SPEC_UX.md`](docs/DESIGN_SPEC_UX.md) e [`docs/MICROCOPY_*.yaml`](docs).
+
 #### Como estender com nova página
 
 1. Crie `app/pages/page_nova.py` com `render(translator: I18N) -> None`.
 2. Use componentes do design system (`card`, `alert`, `toolbar`) e serviços.
 3. Registre a página em `PAGES` dentro de `app/streamlit_app.py`.
+4. Adicione microcópia em `docs/MICROCOPY_*.yaml` e traduções em `app/i18n/locales/*.json`.
+5. Rode `python -m app.services.i18n_lint` e `pytest -q` para garantir cobertura.
+
+#### Qualidade contínua
+
+- `python -m app.services.i18n_lint` garante paridade de chaves pt/en.
+- `python -m app.services.linkcheck` valida links internos do README e da Design Spec.
+- `pytest -q` cobre o fluxo guiado, helpers de acessibilidade e integrações básicas.
 
 ### Gradio (fallback)
 

--- a/ogum-ml-lite/app/design/a11y.py
+++ b/ogum-ml-lite/app/design/a11y.py
@@ -1,0 +1,40 @@
+"""Accessibility helpers for the Streamlit UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FocusHint:
+    """Structured representation of a focus hint message."""
+
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - simple delegation
+        return self.message
+
+
+def focus_hint(message: str | None = None) -> FocusHint:
+    """Return a keyboard navigation hint for captions/tooltips."""
+
+    base = "Use Tab/Shift+Tab to navigate."
+    text = message.strip() if message else base
+    return FocusHint(text)
+
+
+def aria_label(text: str) -> dict[str, str]:
+    """Return kwargs that attach an accessible description to components."""
+
+    if not text:
+        return {"help": ""}
+    return {"help": text}
+
+
+def describe_chart(summary: str, *, prefix: str = "📈") -> str:
+    """Return a concise textual description for charts."""
+
+    text = summary.strip()
+    if not text:
+        text = "Chart summary unavailable"
+    return f"{prefix} {text}".strip()

--- a/ogum-ml-lite/app/i18n/locales/en.json
+++ b/ogum-ml-lite/app/i18n/locales/en.json
@@ -4,6 +4,7 @@
     "subtitle": "Evolutionary frontend"
   },
   "menu": {
+    "wizard": "Guided mode",
     "prep": "Prep & Validate",
     "features": "Features",
     "msc": "θ & MSC",
@@ -39,5 +40,104 @@
     "preset_applied": "[ok] Preset updated",
     "validation_ok": "[ok] File validated",
     "validation_failed": "[warn] Issues detected"
+  },
+  "wizard": {
+    "title": "Guided mode",
+    "intro": "Run the full pipeline step by step.",
+    "focus_hint": "Use Tab/Shift+Tab to move and Enter to trigger buttons.",
+    "actions": {
+      "previous": "Back",
+      "next": "Next",
+      "run_step": "Run step",
+      "open_artifact": "Open artifacts"
+    },
+    "tooltips": {
+      "data": "Upload or select an existing CSV and validate it before preparing.",
+      "features": "Build features from the prepared CSV or reuse a custom file.",
+      "msc": "Run θ/MSC choosing your preferred collapse metric.",
+      "segments": "Compute segmentation and Blaine using fixed or data-driven strategy.",
+      "mechanism": "Analyse mechanism change with τ and R².",
+      "ml": "Train classification or regression models and optionally generate predictions.",
+      "export": "Finish by exporting the report and the session ZIP bundle."
+    },
+    "steps": {
+      "data": {
+        "title": "Data",
+        "description": "Select, validate and prepare the base dataset."
+      },
+      "features": {
+        "title": "Features",
+        "description": "Build global or reprocessed features."
+      },
+      "msc": {
+        "title": "θ & MSC",
+        "description": "Inspect curve collapse and Ea metrics."
+      },
+      "segments": {
+        "title": "Segmentation & Blaine",
+        "description": "Generate fixed or data-driven segmentation."
+      },
+      "mechanism": {
+        "title": "Mechanism",
+        "description": "Mechanism change report per sample."
+      },
+      "ml": {
+        "title": "ML",
+        "description": "Train models and optionally produce predictions."
+      },
+      "export": {
+        "title": "Export",
+        "description": "Assemble the final report and ZIP package."
+      }
+    },
+    "blockers": {
+      "need_prep": "[warn] Generate the prepared CSV before moving on.",
+      "need_features": "[warn] Build the features file to continue.",
+      "need_theta": "[warn] Run θ/MSC to unlock this step.",
+      "need_segments": "[warn] Run segmentation first.",
+      "need_mechanism": "[warn] Run mechanism before ML.",
+      "need_ml": "[warn] Train a model before exporting."
+    },
+    "features": {
+      "use_prep": "Use prep.csv as input"
+    }
+  },
+  "microcopy": {
+    "select_csv": "Select the CSV",
+    "upload_csv": "Upload CSV",
+    "validate_data": "Validate data",
+    "run_prep": "Prepare data",
+    "run_features": "Generate features",
+    "run_msc": "Run MSC",
+    "run_segments": "Generate segmentation",
+    "run_mechanism": "Run mechanism",
+    "run_ml_cls": "Train classification",
+    "run_ml_reg": "Train regression",
+    "run_ml_predict": "Generate predictions",
+    "run_export": "Build export",
+    "prep_ready": "[ok] Data prepared",
+    "validation_ok": "[ok] Data validated successfully",
+    "validation_warn": "[warn] Validation reported warnings",
+    "features_ready": "[ok] Features available",
+    "msc_ready": "[ok] θ/MSC updated",
+    "segments_ready": "[ok] Segmentation saved",
+    "mechanism_ready": "[ok] Mechanism report saved",
+    "ml_ready": "[ok] ML artifacts generated",
+    "predict_ready": "[ok] Predictions ready",
+    "export_ready": "[ok] Report and ZIP updated",
+    "missing_artifact": "[warn] No artifact available",
+    "spinner_prep": "Running preparation...",
+    "spinner_features": "Building features...",
+    "spinner_msc": "Running θ/MSC...",
+    "spinner_segments": "Computing segmentation...",
+    "spinner_mechanism": "Computing mechanism...",
+    "spinner_ml": "Training model...",
+    "spinner_predict": "Generating predictions...",
+    "spinner_export": "Assembling export...",
+    "focus_primary": "Focus on this step: review results before moving on.",
+    "describe_msc": "MSC: mean curve with ±1σ band.",
+    "describe_segments": "Segments: table with fractions per stage.",
+    "describe_mechanism": "Mechanism: report with τ, R² and detected thresholds.",
+    "describe_ml": "ML: cross-validation metrics per model."
   }
 }

--- a/ogum-ml-lite/app/i18n/locales/pt.json
+++ b/ogum-ml-lite/app/i18n/locales/pt.json
@@ -4,6 +4,7 @@
     "subtitle": "Frontend evolutivo"
   },
   "menu": {
+    "wizard": "Modo guiado",
     "prep": "Preparar & Validar",
     "features": "Features",
     "msc": "θ & MSC",
@@ -39,5 +40,104 @@
     "preset_applied": "[ok] Preset atualizado",
     "validation_ok": "[ok] Arquivo validado",
     "validation_failed": "[warn] Problemas encontrados"
+  },
+  "wizard": {
+    "title": "Modo guiado",
+    "intro": "Execute o pipeline completo passo a passo.",
+    "focus_hint": "Use Tab/Shift+Tab para navegar e Enter para acionar botões.",
+    "actions": {
+      "previous": "Voltar",
+      "next": "Avançar",
+      "run_step": "Rodar etapa",
+      "open_artifact": "Abrir artefatos"
+    },
+    "tooltips": {
+      "data": "Carregue ou selecione um CSV existente e valide antes de preparar.",
+      "features": "Gere features a partir do CSV preparado ou reaproveite um arquivo custom.",
+      "msc": "Execute θ/MSC escolhendo a métrica de colapso preferida.",
+      "segments": "Calcule segmentação e Blaine; escolha modo fixo ou data-driven.",
+      "mechanism": "Analise mudança de mecanismo com τ e R².",
+      "ml": "Treine modelos de classificação ou regressão e, se quiser, gere predições.",
+      "export": "Finalize exportando relatório e pacote ZIP da sessão."
+    },
+    "steps": {
+      "data": {
+        "title": "Dados",
+        "description": "Selecione, valide e prepare o dataset base."
+      },
+      "features": {
+        "title": "Features",
+        "description": "Construa features globais ou reprocessadas."
+      },
+      "msc": {
+        "title": "θ & MSC",
+        "description": "Avalie colapso da curva e métricas Ea."
+      },
+      "segments": {
+        "title": "Segmentação & Blaine",
+        "description": "Gere segmentação fixa ou orientada por dados."
+      },
+      "mechanism": {
+        "title": "Mecanismo",
+        "description": "Relatório de mudança de mecanismo por amostra."
+      },
+      "ml": {
+        "title": "ML",
+        "description": "Treine modelos e opcionalmente gere predições."
+      },
+      "export": {
+        "title": "Exportar",
+        "description": "Monte o relatório final e o pacote ZIP."
+      }
+    },
+    "blockers": {
+      "need_prep": "[warn] Gere o CSV preparado antes de avançar.",
+      "need_features": "[warn] Gere o arquivo de features para continuar.",
+      "need_theta": "[warn] Rode θ/MSC para liberar este passo.",
+      "need_segments": "[warn] Execute a segmentação primeiro.",
+      "need_mechanism": "[warn] Rode mecanismo antes de treinar ML.",
+      "need_ml": "[warn] Treine um modelo antes de exportar."
+    },
+    "features": {
+      "use_prep": "Usar prep.csv como entrada"
+    }
+  },
+  "microcopy": {
+    "select_csv": "Selecione o CSV",
+    "upload_csv": "Enviar CSV",
+    "validate_data": "Validar dados",
+    "run_prep": "Preparar dados",
+    "run_features": "Gerar features",
+    "run_msc": "Executar MSC",
+    "run_segments": "Gerar segmentação",
+    "run_mechanism": "Rodar mecanismo",
+    "run_ml_cls": "Treinar classificação",
+    "run_ml_reg": "Treinar regressão",
+    "run_ml_predict": "Gerar predições",
+    "run_export": "Gerar exportação",
+    "prep_ready": "[ok] Dados preparados",
+    "validation_ok": "[ok] Dados validados com sucesso",
+    "validation_warn": "[warn] Validação encontrou avisos",
+    "features_ready": "[ok] Features disponíveis",
+    "msc_ready": "[ok] θ/MSC atualizado",
+    "segments_ready": "[ok] Segmentação salva",
+    "mechanism_ready": "[ok] Relatório de mecanismo salvo",
+    "ml_ready": "[ok] Artefatos de ML gerados",
+    "predict_ready": "[ok] Predições prontas",
+    "export_ready": "[ok] Relatório e ZIP atualizados",
+    "missing_artifact": "[warn] Nenhum artefato disponível",
+    "spinner_prep": "Executando preparação...",
+    "spinner_features": "Gerando features...",
+    "spinner_msc": "Executando θ/MSC...",
+    "spinner_segments": "Calculando segmentação...",
+    "spinner_mechanism": "Calculando mecanismo...",
+    "spinner_ml": "Treinando modelo...",
+    "spinner_predict": "Gerando predições...",
+    "spinner_export": "Montando exportação...",
+    "focus_primary": "Foco nesta etapa: revise resultados antes de avançar.",
+    "describe_msc": "MSC: curva média com faixa ±1σ.",
+    "describe_segments": "Segmentos: tabela com frações por estágio.",
+    "describe_mechanism": "Mecanismo: relatório com τ, R² e limiares detectados.",
+    "describe_ml": "ML: métricas de validação cruzada por modelo."
   }
 }

--- a/ogum-ml-lite/app/pages/__init__.py
+++ b/ogum-ml-lite/app/pages/__init__.py
@@ -8,6 +8,7 @@ from . import (
     page_msc,
     page_prep,
     page_segments,
+    page_wizard,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "page_msc",
     "page_prep",
     "page_segments",
+    "page_wizard",
 ]

--- a/ogum-ml-lite/app/pages/page_export.py
+++ b/ogum-ml-lite/app/pages/page_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from ..design.a11y import aria_label, focus_hint
 from ..i18n.translate import I18N
 from ..services import run_cli, state
 
@@ -12,16 +13,21 @@ def render(translator: I18N) -> None:
     """Render export utilities."""
 
     st.subheader(translator.t("menu.export"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
     workspace = state.get_workspace()
     preset = state.get_preset()
 
-    if st.button(translator.t("actions.export"), key="export_run"):
-        with st.spinner("Gerando artefatos..."):
+    if st.button(
+        translator.t("actions.export"),
+        key="export_run",
+        **aria_label(translator.t("microcopy.run_export")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_export")):
             result = run_cli.export_report(workspace.path, preset, workspace)
         for key, path in result.outputs.items():
             state.register_artifact(f"export_{key}", path, description="export")
         state.register_artifact("session_zip", result.outputs["zip"], description="zip")
-        st.toast(translator.t("messages.ready"))
+        st.toast(translator.t("microcopy.export_ready"))
 
     report = state.get_artifact("export_report")
     if report and report.exists():

--- a/ogum-ml-lite/app/pages/page_features.py
+++ b/ogum-ml-lite/app/pages/page_features.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
+from ..design.a11y import aria_label, focus_hint
 from ..i18n.translate import I18N
 from ..services import run_cli, state, validators
 
@@ -13,34 +14,43 @@ def render(translator: I18N) -> None:
     """Render the feature engineering workflow."""
 
     st.subheader(translator.t("menu.features"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
     workspace = state.get_workspace()
     preset = state.get_preset()
 
     prep_csv = state.get_artifact("prep_csv")
     if prep_csv is None:
-        st.info(translator.t("messages.no_artifacts"))
+        st.info(translator.t("wizard.blockers.need_prep"))
         return
 
     run_cols = st.columns(2)
-    if run_cols[0].button(translator.t("actions.run"), key="features_run"):
-        with st.spinner("Extraindo features..."):
+    if run_cols[0].button(
+        translator.t("actions.run"),
+        key="features_run",
+        **aria_label(translator.t("microcopy.run_features")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_features")):
             result = run_cli.run_features(prep_csv, preset, workspace)
         features_csv = result.outputs["features_csv"]
         state.register_artifact("features_csv", features_csv, description="features")
-        st.toast(translator.t("messages.ready"))
+        st.toast(translator.t("microcopy.features_ready"))
 
     features_csv = state.get_artifact("features_csv")
     if features_csv and features_csv.exists():
         if run_cols[1].button(
-            translator.t("actions.validate"), key="features_validate"
+            translator.t("actions.validate"),
+            key="features_validate",
+            **aria_label(translator.t("microcopy.validate_data")),
         ):
             summary = validators.validate_features(features_csv)
             if summary.ok:
-                st.toast(translator.t("messages.validation_ok"))
+                st.toast(translator.t("microcopy.validation_ok"))
+            else:
+                st.toast(translator.t("microcopy.validation_warn"))
             for issue in summary.issues:
                 st.warning(issue)
 
         st.caption(f"Preview · {features_csv.name}")
         st.dataframe(pd.read_csv(features_csv).head(25))
     else:
-        st.info(translator.t("messages.no_artifacts"))
+        st.info(translator.t("microcopy.missing_artifact"))

--- a/ogum-ml-lite/app/pages/page_mechanism.py
+++ b/ogum-ml-lite/app/pages/page_mechanism.py
@@ -1,10 +1,11 @@
-"""Mechanism analysis page."""
+"""Mechanism detection Streamlit page."""
 
 from __future__ import annotations
 
 import pandas as pd
 import streamlit as st
 
+from ..design.a11y import aria_label, describe_chart, focus_hint
 from ..i18n.translate import I18N
 from ..services import run_cli, state
 
@@ -13,25 +14,33 @@ def render(translator: I18N) -> None:
     """Render mechanism detection workflow."""
 
     st.subheader(translator.t("menu.mechanism"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
     workspace = state.get_workspace()
     preset = state.get_preset()
 
     theta_table = state.get_artifact("theta_table")
     if theta_table is None:
-        st.info(translator.t("messages.no_artifacts"))
+        st.info(translator.t("wizard.blockers.need_theta"))
         return
 
-    if st.button(translator.t("actions.run"), key="mechanism_run"):
-        with st.spinner("Calculando mecanismo..."):
+    if st.button(
+        translator.t("actions.run"),
+        key="mechanism_run",
+        **aria_label(translator.t("microcopy.run_mechanism")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_mechanism")):
             result = run_cli.run_mechanism(theta_table, preset, workspace)
         mech_path = result.outputs["mechanism"]
         state.register_artifact("mechanism", mech_path, description="mechanism")
-        st.toast(translator.t("messages.ready"))
+        st.toast(translator.t("microcopy.mechanism_ready"))
 
     mech_path = state.get_artifact("mechanism")
     if mech_path and mech_path.exists():
         df = pd.read_csv(mech_path)
         st.dataframe(df.head(50))
+        st.caption(
+            describe_chart(translator.t("microcopy.describe_mechanism"), prefix="🧪")
+        )
         st.download_button(
             label=f"CSV · {mech_path.name}",
             data=mech_path.read_bytes(),

--- a/ogum-ml-lite/app/pages/page_ml.py
+++ b/ogum-ml-lite/app/pages/page_ml.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 import streamlit as st
 
+from ..design.a11y import aria_label, describe_chart, focus_hint
 from ..i18n.translate import I18N
 from ..services import run_cli, state
 
@@ -29,41 +30,54 @@ def render(translator: I18N) -> None:
     """Render ML training and inference workflow."""
 
     st.subheader(translator.t("menu.ml"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
     workspace = state.get_workspace()
     preset = state.get_preset()
     features_csv = state.get_artifact("features_csv")
     if features_csv is None:
-        st.info(translator.t("messages.no_artifacts"))
+        st.info(translator.t("wizard.blockers.need_features"))
         return
 
     tab_train_cls, tab_train_reg, tab_predict = st.tabs(
-        ["Train CLS", "Train REG", "Predict"]
+        [
+            translator.t("microcopy.run_ml_cls"),
+            translator.t("microcopy.run_ml_reg"),
+            translator.t("actions.predict"),
+        ]
     )
 
     with tab_train_cls:
-        if st.button(translator.t("actions.train"), key="ml_train_cls"):
-            with st.spinner("Treinando classificador..."):
+        if st.button(
+            translator.t("actions.train"),
+            key="ml_train_cls",
+            **aria_label(translator.t("microcopy.run_ml_cls")),
+        ):
+            with st.spinner(translator.t("microcopy.spinner_ml")):
                 result = run_cli.run_ml_train_cls(features_csv, preset, workspace)
             outdir = result.outputs["outdir"]
             state.register_artifact("ml_cls", outdir, description="ml_cls")
             state.register_artifact(
                 "ml_cls_card", result.outputs["model_card"], description="ml_cls"
             )
-            st.toast(translator.t("messages.ready"))
+            st.toast(translator.t("microcopy.ml_ready"))
             card = _load_card(result.outputs["model_card"])
             if card:
                 st.json(card)
 
     with tab_train_reg:
-        if st.button(translator.t("actions.train"), key="ml_train_reg"):
-            with st.spinner("Treinando regressor..."):
+        if st.button(
+            translator.t("actions.train"),
+            key="ml_train_reg",
+            **aria_label(translator.t("microcopy.run_ml_reg")),
+        ):
+            with st.spinner(translator.t("microcopy.spinner_ml")):
                 result = run_cli.run_ml_train_reg(features_csv, preset, workspace)
             outdir = result.outputs["outdir"]
             state.register_artifact("ml_reg", outdir, description="ml_reg")
             state.register_artifact(
                 "ml_reg_card", result.outputs["model_card"], description="ml_reg"
             )
-            st.toast(translator.t("messages.ready"))
+            st.toast(translator.t("microcopy.ml_ready"))
             card = _load_card(result.outputs["model_card"])
             if card:
                 st.json(card)
@@ -71,13 +85,17 @@ def render(translator: I18N) -> None:
     with tab_predict:
         models = _list_models(workspace.path)
         option = st.selectbox(
-            "Modelo",
+            translator.t("microcopy.run_ml_predict"),
             options=[str(path) for path in models],
             format_func=lambda value: Path(value).name,
             key="ml_model_pick",
         )
-        if option and st.button(translator.t("actions.predict"), key="ml_predict"):
-            with st.spinner("Gerando predições..."):
+        if option and st.button(
+            translator.t("actions.predict"),
+            key="ml_predict",
+            **aria_label(translator.t("microcopy.run_ml_predict")),
+        ):
+            with st.spinner(translator.t("microcopy.spinner_predict")):
                 result = run_cli.run_ml_predict(
                     features_csv, Path(option), preset, workspace
                 )
@@ -85,10 +103,13 @@ def render(translator: I18N) -> None:
             state.register_artifact(
                 "predictions", predictions, description="predictions"
             )
-            st.toast(translator.t("messages.ready"))
+            st.toast(translator.t("microcopy.predict_ready"))
         predictions = state.get_artifact("predictions")
         if predictions and predictions.exists():
             st.dataframe(pd.read_csv(predictions).head(25))
+            st.caption(
+                describe_chart(translator.t("microcopy.describe_ml"), prefix="🤖")
+            )
             st.download_button(
                 label=f"CSV · {predictions.name}",
                 data=predictions.read_bytes(),

--- a/ogum-ml-lite/app/pages/page_segments.py
+++ b/ogum-ml-lite/app/pages/page_segments.py
@@ -7,6 +7,7 @@ import json
 import pandas as pd
 import streamlit as st
 
+from ..design.a11y import aria_label, describe_chart, focus_hint
 from ..i18n.translate import I18N
 from ..services import run_cli, state
 
@@ -15,19 +16,24 @@ def render(translator: I18N) -> None:
     """Render the segmentation pipeline."""
 
     st.subheader(translator.t("menu.segments"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
     workspace = state.get_workspace()
     preset = state.get_preset()
     prep_csv = state.get_artifact("prep_csv")
     if prep_csv is None:
-        st.info(translator.t("messages.no_artifacts"))
+        st.info(translator.t("wizard.blockers.need_prep"))
         return
 
-    if st.button(translator.t("actions.run"), key="segmentation_run"):
-        with st.spinner("Segmentando..."):
+    if st.button(
+        translator.t("actions.run"),
+        key="segmentation_run",
+        **aria_label(translator.t("microcopy.run_segments")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_segments")):
             result = run_cli.run_segmentation(prep_csv, preset, workspace)
         segments_path = result.outputs["segments"]
         state.register_artifact("segments", segments_path, description="segments")
-        st.toast(translator.t("messages.ready"))
+        st.toast(translator.t("microcopy.segments_ready"))
 
     segments_path = state.get_artifact("segments")
     if segments_path and segments_path.exists():
@@ -37,6 +43,9 @@ def render(translator: I18N) -> None:
             st.code(segments_path.read_text(encoding="utf-8"), language="json")
         else:
             st.dataframe(pd.DataFrame(data))
+            st.caption(
+                describe_chart(translator.t("microcopy.describe_segments"), prefix="🧮")
+            )
         st.download_button(
             label=f"JSON · {segments_path.name}",
             data=segments_path.read_bytes(),

--- a/ogum-ml-lite/app/pages/page_wizard.py
+++ b/ogum-ml-lite/app/pages/page_wizard.py
@@ -1,0 +1,503 @@
+"""Guided wizard page orchestrating the Ogum pipeline end-to-end."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from ..design.a11y import aria_label, describe_chart, focus_hint
+from ..i18n.translate import I18N
+from ..services import run_cli, state, validators
+
+STATE_KEY = "wizard_step"
+FLAGS_KEY = "wizard_flags"
+CONTEXT_KEY = "wizard_context"
+
+
+@dataclass(frozen=True)
+class WizardStep:
+    """Definition for a wizard step."""
+
+    key: str
+    renderer: Callable[[I18N], None]
+    blocker_key: str | None = None
+
+
+def _context() -> dict[str, Any]:
+    return st.session_state.setdefault(CONTEXT_KEY, {})
+
+
+def _flags() -> dict[str, bool]:
+    flags: dict[str, bool] = st.session_state.setdefault(FLAGS_KEY, {})
+    return flags
+
+
+def _mark_complete(step_key: str) -> None:
+    flags = _flags()
+    flags[step_key] = True
+    st.session_state[FLAGS_KEY] = flags
+
+
+def _is_complete(step_key: str) -> bool:
+    return _flags().get(step_key, False)
+
+
+def _artifact_exists(key: str) -> bool:
+    path = state.get_artifact(key)
+    return bool(path and path.exists())
+
+
+def _sync_flags() -> None:
+    auto_rules: dict[str, Callable[[], bool]] = {
+        "data": lambda: _artifact_exists("prep_csv"),
+        "features": lambda: _artifact_exists("features_csv"),
+        "msc": lambda: _artifact_exists("theta_table"),
+        "segments": lambda: _artifact_exists("segments"),
+        "mechanism": lambda: _artifact_exists("mechanism"),
+        "ml": lambda: _artifact_exists("ml_cls")
+        or _artifact_exists("ml_reg")
+        or _artifact_exists("predictions"),
+        "export": lambda: _artifact_exists("export_report")
+        and _artifact_exists("session_zip"),
+    }
+    flags = _flags()
+    for key, rule in auto_rules.items():
+        if not flags.get(key) and rule():
+            flags[key] = True
+    st.session_state[FLAGS_KEY] = flags
+
+
+def _init_state() -> None:
+    st.session_state.setdefault(STATE_KEY, 0)
+    _context()
+    _sync_flags()
+
+
+def _render_step_progress(translator: I18N, current_index: int) -> None:
+    cols = st.columns(len(STEPS))
+    for idx, step in enumerate(STEPS):
+        label = translator.t(f"wizard.steps.{step.key}.title")
+        description = translator.t(f"wizard.steps.{step.key}.description")
+        status = (
+            "✅" if _is_complete(step.key) else ("🟡" if idx == current_index else "⚪")
+        )
+        cols[idx].markdown(f"{status} **{label}**")
+        if idx == current_index:
+            cols[idx].caption(description)
+
+
+def _render_navigation(translator: I18N, current_index: int, step: WizardStep) -> None:
+    cols = st.columns([1, 1, 3])
+    if cols[0].button(
+        translator.t("wizard.actions.previous"),
+        key=f"wizard_prev_{current_index}",
+        disabled=current_index == 0,
+        **aria_label(translator.t("wizard.actions.previous")),
+    ):
+        st.session_state[STATE_KEY] = max(0, current_index - 1)
+
+    can_advance = current_index < len(STEPS) - 1 and _is_complete(step.key)
+    if not can_advance and step.blocker_key:
+        cols[2].caption(translator.t(step.blocker_key))
+
+    if cols[1].button(
+        translator.t("wizard.actions.next"),
+        key=f"wizard_next_{current_index}",
+        disabled=not can_advance,
+        **aria_label(translator.t("wizard.actions.next")),
+    ):
+        st.session_state[STATE_KEY] = min(len(STEPS) - 1, current_index + 1)
+
+
+def _list_csv(workspace_path: Path) -> list[Path]:
+    uploads = workspace_path / "uploads"
+    if not uploads.exists():
+        return []
+    return sorted(uploads.glob("*.csv"))
+
+
+def _render_data_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    ctx = _context()
+
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.data')}")
+    uploaded = st.file_uploader(
+        translator.t("microcopy.upload_csv"),
+        type=["csv"],
+        key="wizard_upload",
+        **aria_label(translator.t("microcopy.upload_csv")),
+    )
+    if uploaded is not None:
+        target = state.persist_upload(uploaded)
+        st.toast(f"[ok] {uploaded.name} → {target.name}")
+
+    csv_files = _list_csv(workspace.path)
+    if not csv_files:
+        st.info(translator.t("microcopy.missing_artifact"))
+        return
+
+    default = ctx.get("selected_csv")
+    option = st.selectbox(
+        translator.t("microcopy.select_csv"),
+        options=[str(path) for path in csv_files],
+        format_func=lambda value: Path(value).name,
+        key="wizard_dataset",
+        index=(
+            [str(path) for path in csv_files].index(default)
+            if default in [str(path) for path in csv_files]
+            else 0
+        ),
+    )
+    selected = Path(option)
+    ctx["selected_csv"] = str(selected)
+
+    cols = st.columns(2)
+    if cols[0].button(
+        translator.t("microcopy.validate_data"),
+        key="wizard_validate",
+        **aria_label(translator.t("microcopy.validate_data")),
+    ):
+        summary = validators.validate_long(selected)
+        if summary.ok:
+            st.toast(translator.t("microcopy.validation_ok"))
+        else:
+            st.toast(translator.t("microcopy.validation_warn"))
+        for issue in summary.issues:
+            st.warning(issue)
+
+    if cols[1].button(
+        translator.t("microcopy.run_prep"),
+        key="wizard_prep",
+        **aria_label(translator.t("microcopy.run_prep")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_prep")):
+            result = run_cli.run_prep(selected, preset, workspace)
+        prep_csv = result.outputs["prep_csv"]
+        state.register_artifact("prep_csv", prep_csv, description="prep")
+        st.toast(translator.t("microcopy.prep_ready"))
+        _mark_complete("data")
+
+    preview_target = state.get_artifact("prep_csv") or selected
+    if preview_target.exists():
+        st.caption(translator.t("microcopy.focus_primary"))
+        st.dataframe(pd.read_csv(preview_target).head(30))
+
+
+def _render_features_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.features')}")
+
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None or not prep_csv.exists():
+        st.info(translator.t("wizard.blockers.need_prep"))
+        return
+
+    ctx = _context()
+    use_prep = st.checkbox(
+        translator.t("wizard.features.use_prep"),
+        value=ctx.get("features_use_prep", True),
+        key="wizard_features_use_prep",
+    )
+    ctx["features_use_prep"] = use_prep
+
+    if st.button(
+        translator.t("microcopy.run_features"),
+        key="wizard_features_run",
+        **aria_label(translator.t("microcopy.run_features")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_features")):
+            result = run_cli.run_features(
+                prep_csv,
+                preset,
+                workspace,
+                use_prep=use_prep,
+            )
+        features_csv = result.outputs["features_csv"]
+        state.register_artifact("features_csv", features_csv, description="features")
+        st.toast(translator.t("microcopy.features_ready"))
+        _mark_complete("features")
+
+    features_csv = state.get_artifact("features_csv")
+    if features_csv and features_csv.exists():
+        st.dataframe(pd.read_csv(features_csv).head(25))
+    else:
+        st.info(translator.t("microcopy.missing_artifact"))
+
+
+def _render_msc_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None or not prep_csv.exists():
+        st.info(translator.t("wizard.blockers.need_prep"))
+        return
+
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.msc')}")
+    if st.button(
+        translator.t("microcopy.run_msc"),
+        key="wizard_msc_run",
+        **aria_label(translator.t("microcopy.run_msc")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_msc")):
+            result = run_cli.run_theta_msc(prep_csv, preset, workspace)
+        for key, path in result.outputs.items():
+            state.register_artifact(key, path, description="msc")
+        st.toast(translator.t("microcopy.msc_ready"))
+        _mark_complete("msc")
+
+    curve_path = state.get_artifact("msc_curve")
+    if curve_path and curve_path.exists():
+        df = pd.read_csv(curve_path)
+        if {"Ea_kJ", "metric"}.issubset(df.columns):
+            figure = px.line(df, x="Ea_kJ", y="metric", markers=True)
+            st.plotly_chart(figure, use_container_width=True)
+            st.caption(describe_chart(translator.t("microcopy.describe_msc")))
+        st.download_button(
+            label=f"CSV · {curve_path.name}",
+            data=curve_path.read_bytes(),
+            file_name=curve_path.name,
+            key="wizard_msc_csv",
+        )
+
+
+def _render_segments_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    prep_csv = state.get_artifact("prep_csv")
+    if prep_csv is None or not prep_csv.exists():
+        st.info(translator.t("wizard.blockers.need_prep"))
+        return
+
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.segments')}")
+    if st.button(
+        translator.t("microcopy.run_segments"),
+        key="wizard_segments_run",
+        **aria_label(translator.t("microcopy.run_segments")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_segments")):
+            result = run_cli.run_segmentation(prep_csv, preset, workspace)
+        segments_path = result.outputs["segments"]
+        state.register_artifact("segments", segments_path, description="segments")
+        st.toast(translator.t("microcopy.segments_ready"))
+        _mark_complete("segments")
+
+    segments_path = state.get_artifact("segments")
+    if segments_path and segments_path.exists():
+        try:
+            payload = json.loads(segments_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            st.code(segments_path.read_text(encoding="utf-8"), language="json")
+        else:
+            st.dataframe(pd.DataFrame(payload))
+            st.caption(
+                describe_chart(translator.t("microcopy.describe_segments"), prefix="🧮")
+            )
+        st.download_button(
+            label=f"JSON · {segments_path.name}",
+            data=segments_path.read_bytes(),
+            file_name=segments_path.name,
+            key="wizard_segments_json",
+        )
+
+
+def _render_mechanism_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    theta_table = state.get_artifact("theta_table")
+    if theta_table is None or not theta_table.exists():
+        st.info(translator.t("wizard.blockers.need_theta"))
+        return
+
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.mechanism')}")
+    if st.button(
+        translator.t("microcopy.run_mechanism"),
+        key="wizard_mechanism_run",
+        **aria_label(translator.t("microcopy.run_mechanism")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_mechanism")):
+            result = run_cli.run_mechanism(theta_table, preset, workspace)
+        mech_path = result.outputs["mechanism"]
+        state.register_artifact("mechanism", mech_path, description="mechanism")
+        st.toast(translator.t("microcopy.mechanism_ready"))
+        _mark_complete("mechanism")
+
+    mech_path = state.get_artifact("mechanism")
+    if mech_path and mech_path.exists():
+        st.dataframe(pd.read_csv(mech_path).head(50))
+        st.caption(
+            describe_chart(translator.t("microcopy.describe_mechanism"), prefix="🧪")
+        )
+        st.download_button(
+            label=f"CSV · {mech_path.name}",
+            data=mech_path.read_bytes(),
+            file_name=mech_path.name,
+            key="wizard_mechanism_csv",
+        )
+
+
+def _render_ml_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    features_csv = state.get_artifact("features_csv")
+    if features_csv is None or not features_csv.exists():
+        st.info(translator.t("wizard.blockers.need_features"))
+        return
+
+    mechanism = state.get_artifact("mechanism")
+    if mechanism is None or not mechanism.exists():
+        st.warning(translator.t("wizard.blockers.need_mechanism"))
+
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.ml')}")
+    cols = st.columns(2)
+    if cols[0].button(
+        translator.t("microcopy.run_ml_cls"),
+        key="wizard_ml_cls",
+        **aria_label(translator.t("microcopy.run_ml_cls")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_ml")):
+            result = run_cli.run_ml_train_cls(features_csv, preset, workspace)
+        outdir = result.outputs["outdir"]
+        state.register_artifact("ml_cls", outdir, description="ml_cls")
+        state.register_artifact(
+            "ml_cls_card", result.outputs["model_card"], description="ml_cls"
+        )
+        st.toast(translator.t("microcopy.ml_ready"))
+        _mark_complete("ml")
+        if result.stdout:
+            st.code(result.stdout)
+
+    if cols[1].button(
+        translator.t("microcopy.run_ml_reg"),
+        key="wizard_ml_reg",
+        **aria_label(translator.t("microcopy.run_ml_reg")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_ml")):
+            result = run_cli.run_ml_train_reg(features_csv, preset, workspace)
+        outdir = result.outputs["outdir"]
+        state.register_artifact("ml_reg", outdir, description="ml_reg")
+        state.register_artifact(
+            "ml_reg_card", result.outputs["model_card"], description="ml_reg"
+        )
+        st.toast(translator.t("microcopy.ml_ready"))
+        _mark_complete("ml")
+        if result.stdout:
+            st.code(result.stdout)
+
+    models = sorted(workspace.path.rglob("*.joblib"))
+    option = st.selectbox(
+        translator.t("microcopy.run_ml_predict"),
+        options=[str(path) for path in models],
+        format_func=lambda value: Path(value).name,
+        key="wizard_ml_model",
+    )
+    if option and st.button(
+        translator.t("microcopy.run_ml_predict"),
+        key="wizard_ml_predict",
+        **aria_label(translator.t("microcopy.run_ml_predict")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_predict")):
+            result = run_cli.run_ml_predict(
+                features_csv, Path(option), preset, workspace
+            )
+        predictions = result.outputs["predictions"]
+        state.register_artifact("predictions", predictions, description="predictions")
+        st.toast(translator.t("microcopy.predict_ready"))
+        _mark_complete("ml")
+
+    predictions = state.get_artifact("predictions")
+    if predictions and predictions.exists():
+        st.dataframe(pd.read_csv(predictions).head(25))
+        st.caption(describe_chart(translator.t("microcopy.describe_ml"), prefix="🤖"))
+        st.download_button(
+            label=f"CSV · {predictions.name}",
+            data=predictions.read_bytes(),
+            file_name=predictions.name,
+            key="wizard_predictions_csv",
+        )
+
+
+def _render_export_step(translator: I18N) -> None:
+    workspace = state.get_workspace()
+    preset = state.get_preset()
+    st.caption(f"ⓘ {translator.t('wizard.tooltips.export')}")
+
+    if st.button(
+        translator.t("microcopy.run_export"),
+        key="wizard_export_run",
+        **aria_label(translator.t("microcopy.run_export")),
+    ):
+        with st.spinner(translator.t("microcopy.spinner_export")):
+            result = run_cli.export_report(workspace.path, preset, workspace)
+        for key, path in result.outputs.items():
+            state.register_artifact(f"export_{key}", path, description="export")
+        state.register_artifact("session_zip", result.outputs["zip"], description="zip")
+        st.toast(translator.t("microcopy.export_ready"))
+        _mark_complete("export")
+
+    report = state.get_artifact("export_report")
+    if report and report.exists():
+        st.download_button(
+            label=f"XLSX · {report.name}",
+            data=report.read_bytes(),
+            file_name=report.name,
+            key="wizard_export_xlsx",
+        )
+    zip_path = state.get_artifact("session_zip")
+    if zip_path and zip_path.exists():
+        st.download_button(
+            label=f"ZIP · {zip_path.name}",
+            data=zip_path.read_bytes(),
+            file_name=zip_path.name,
+            key="wizard_export_zip",
+        )
+
+
+STEPS: tuple[WizardStep, ...] = (
+    WizardStep("data", _render_data_step, blocker_key="wizard.blockers.need_prep"),
+    WizardStep(
+        "features", _render_features_step, blocker_key="wizard.blockers.need_features"
+    ),
+    WizardStep("msc", _render_msc_step, blocker_key="wizard.blockers.need_theta"),
+    WizardStep(
+        "segments", _render_segments_step, blocker_key="wizard.blockers.need_segments"
+    ),
+    WizardStep(
+        "mechanism",
+        _render_mechanism_step,
+        blocker_key="wizard.blockers.need_mechanism",
+    ),
+    WizardStep("ml", _render_ml_step, blocker_key="wizard.blockers.need_ml"),
+    WizardStep("export", _render_export_step),
+)
+
+
+def render(translator: I18N) -> None:
+    """Render the guided wizard UI."""
+
+    st.subheader(translator.t("wizard.title"))
+    st.caption(translator.t("wizard.intro"))
+    st.caption(str(focus_hint(translator.t("wizard.focus_hint"))))
+
+    _init_state()
+    current_index = st.session_state.get(STATE_KEY, 0)
+    current_index = max(0, min(current_index, len(STEPS) - 1))
+    st.session_state[STATE_KEY] = current_index
+
+    _render_step_progress(translator, current_index)
+    st.divider()
+
+    step = STEPS[current_index]
+    st.markdown(f"### {translator.t(f'wizard.steps.{step.key}.title')}")
+    st.caption(translator.t(f"wizard.steps.{step.key}.description"))
+
+    step.renderer(translator)
+
+    _render_navigation(translator, current_index, step)

--- a/ogum-ml-lite/app/services/i18n_lint.py
+++ b/ogum-ml-lite/app/services/i18n_lint.py
@@ -1,0 +1,75 @@
+"""Utility to compare translation catalogues and spot missing keys."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping
+
+LOCALES_DIR = Path(__file__).resolve().parents[1] / "i18n" / "locales"
+DEFAULT_LOCALES = ("pt", "en")
+
+
+def _load_locale(locale: str) -> Mapping[str, object]:
+    path = LOCALES_DIR / f"{locale}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Locale file missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _flatten(mapping: Mapping[str, object], prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    for key, value in mapping.items():
+        compound = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+        if isinstance(value, Mapping):
+            keys.update(_flatten(value, compound))
+        else:
+            keys.add(compound)
+    return keys
+
+
+def lint(
+    locales: Iterable[str] = DEFAULT_LOCALES,
+) -> dict[str, MutableMapping[str, set[str]]]:
+    """Return missing/extra keys for each locale."""
+
+    locales = tuple(locales)
+    if not locales:
+        raise ValueError("At least one locale must be provided")
+
+    keysets = {locale: _flatten(_load_locale(locale)) for locale in locales}
+    union: set[str] = set().union(*keysets.values())
+    report: dict[str, MutableMapping[str, set[str]]] = {}
+    for locale, keys in keysets.items():
+        missing = union - keys
+        extra = keys - union
+        report[locale] = {"missing": missing, "extra": extra}
+    return report
+
+
+def _format_report(report: Mapping[str, Mapping[str, set[str]]]) -> str:
+    lines: list[str] = []
+    for locale, payload in sorted(report.items()):
+        missing = sorted(payload.get("missing", set()))
+        extra = sorted(payload.get("extra", set()))
+        if not missing and not extra:
+            lines.append(f"{locale}: ok")
+            continue
+        if missing:
+            lines.append(f"{locale}: missing {', '.join(missing)}")
+        if extra:
+            lines.append(f"{locale}: extra {', '.join(extra)}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    locales = tuple(argv or DEFAULT_LOCALES)
+    report = lint(locales)
+    issues = any(payload["missing"] or payload["extra"] for payload in report.values())
+    print(_format_report(report))
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main(sys.argv[1:]))

--- a/ogum-ml-lite/app/services/linkcheck.py
+++ b/ogum-ml-lite/app/services/linkcheck.py
@@ -1,0 +1,56 @@
+"""Simple link checker for local markdown references."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FILES = (
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "DESIGN_SPEC_UX.md",
+)
+_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def _resolve(base: Path, target: str) -> Path:
+    clean = target.split("#", 1)[0].split("?", 1)[0]
+    if not clean:
+        return base
+    if clean.startswith("/"):
+        return (REPO_ROOT / clean.lstrip("/")).resolve()
+    path = Path(clean)
+    return (base.parent / path).resolve()
+
+
+def find_broken_links(files: Iterable[Path]) -> list[tuple[Path, str]]:
+    missing: list[tuple[Path, str]] = []
+    for file_path in files:
+        if not file_path.exists():
+            continue
+        text = file_path.read_text(encoding="utf-8")
+        for match in _LINK_RE.finditer(text):
+            target = match.group(1)
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            resolved = _resolve(file_path, target)
+            if not resolved.exists():
+                missing.append((file_path, target))
+    return missing
+
+
+def main(paths: Sequence[str] | None = None) -> int:
+    files = [Path(p) for p in paths] if paths else list(DEFAULT_FILES)
+    broken = find_broken_links(files)
+    if not broken:
+        print("links: ok")
+        return 0
+    for origin, target in broken:
+        print(f"{origin.relative_to(REPO_ROOT)} -> {target} (missing)")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main(sys.argv[1:]))

--- a/ogum-ml-lite/app/streamlit_app.py
+++ b/ogum-ml-lite/app/streamlit_app.py
@@ -16,10 +16,12 @@ from app.pages import (
     page_msc,
     page_prep,
     page_segments,
+    page_wizard,
 )
 from app.services import state
 
 PAGES: dict[str, tuple[str, Callable[[I18N], None]]] = {
+    "wizard": ("menu.wizard", page_wizard.render),
     "prep": ("menu.prep", page_prep.render),
     "features": ("menu.features", page_features.render),
     "msc": ("menu.msc", page_msc.render),

--- a/ogum-ml-lite/docs/DESIGN_SPEC_UX.md
+++ b/ogum-ml-lite/docs/DESIGN_SPEC_UX.md
@@ -1,0 +1,65 @@
+# Ogum-ML Lite — Design Spec UX (Fase 9)
+
+## Personas e Metas
+
+### Pesquisador de Materiais
+- **Objetivo primário**: validar rapidamente curvas de sinterização, extrair θ(Ea) e gerar relatórios para discussões técnicas.
+- **Necessidades**: feedback imediato de validação, presets confiáveis, possibilidade de explorar dados etapa a etapa.
+- **Pontos de dor**: formatos heterogêneos de planilhas, tempo limitado para reconstruir análises.
+
+### Engenheiro de Processos / Dados
+- **Objetivo primário**: orquestrar pipelines completos (prep → ML) e padronizar artefatos para reuso.
+- **Necessidades**: automação guiada, microcópia objetiva para diminuir ambiguidades, export consistente.
+- **Pontos de dor**: transição entre scripts e UI, rastreabilidade dos artefatos, garantia de cobertura de traduções.
+
+## Fluxos Principais
+1. **Prep** → upload/seleção de CSV, validação e normalização.
+2. **Features** → construção de `features.csv`, opcionalmente reaproveitando `prep.csv`.
+3. **MSC & θ(Ea)** → escolha de amostra/métrica, execução e visualização da curva.
+4. **Segmentação & Blaine** → estratégia fixa ou data-driven e geração de `segments.json`.
+5. **Mecanismo** → relatório por amostra com detecção de mudanças (`τ`, R², AIC/BIC).
+6. **ML** → `train-cls` ou `train-reg`, métricas de validação cruzada, artefatos de modelo e predição opcional.
+7. **Export** → consolidação em `report.xlsx` e `session.zip` com rastreabilidade de presets.
+
+## Estados de UI
+- **Carregando** (`loading`): exibir *spinner* curto com mensagem técnica (ex.: “Executando MSC…”).
+- **Sucesso** (`success`): toasts `[ok]` com microcópia positiva (“Dados validados com sucesso”).
+- **Alerta** (`warning`): destacar ações pendentes ou artefatos ausentes (“Nenhum CSV carregado”).
+- **Falha** (`error`): descrever causa humana + instrução objetiva (“Falha ao gerar features — verifique o preset”).
+
+## Diretrizes de Acessibilidade
+- **Navegação por teclado**: todos os botões essenciais possuem hints de foco e ordem previsível via `st.columns`.
+- **Contraste mínimo**: textos críticos usam componentes padrão Streamlit (apoiados por o tema Ogum) evitando cores custom de baixo contraste.
+- **Foco visível**: mensagens `focus_hint` explicitam atalhos (Tab / Shift+Tab / Enter) para manter contexto.
+- **Descrições textuais**: gráficos Plotly recebem captions descritivas via `describe_chart` (pt/en) com resumo numérico.
+
+## Microcópia
+- **Tom**: técnico, objetivo e breve (no máximo 70 caracteres para toasts e tooltips).
+- **Formato**: prefixos `[ok]`, `[warn]`, `[error]` indicam o estado diretamente.
+- **Idiomas**: `pt` como padrão e `en` completo com fallback automático.
+- **Localização**: todas as chaves residem em `docs/MICROCOPY_*.yaml` e `app/i18n/locales/*.json`. Toda frase usada na UI deve mapear para uma chave única.
+
+## Estados & Artefatos do Wizard
+- Persistência via `session_state` (`wizard_step`, `wizard_flags` e `wizard_context`).
+- Pré-condições rígidas: só avança quando o artefato requerido está presente e registrado em `state.register_artifact`.
+- Tooltips contextualizam decisões (ex.: opção de reaproveitar CSV cru em *Features*).
+- Toasts reutilizam microcópia `[ok]/[warn]/[error]` alinhada ao restante do app.
+
+## Estrutura de Extensão
+- **Componentização**: novos passos devem herdar de `WizardStep` (definido em `page_wizard.py`).
+- **Hooks de serviço**: nenhuma lógica de negócio duplicada; sempre orquestrar via `app/services/run_cli.py`.
+- **Traduções**: toda microcópia adicionada precisa de chaves `pt/en` + atualização do lint (`python -m app.services.i18n_lint`).
+- **Testes**: cenários críticos do wizard cobertos por `tests/test_wizard_flow.py` com mocks simples dos serviços.
+
+## Vocabulário Padronizado
+- **“Validação”**: refere-se à checagem estrutural do CSV.
+- **“Preparação”**: execução do CLI `prep` com geração de `prep.csv`.
+- **“Artefato”**: qualquer arquivo registrado em `state.list_artifacts()`.
+- **“Sessão”**: contexto corrente do workspace (persistido em `artifacts/ui-session`).
+
+## Glossário de Microcópia
+Chaves detalhadas em `docs/MICROCOPY_pt.yaml` / `docs/MICROCOPY_en.yaml` cobrem:
+- Upload, seleção e validação de dados.
+- Execução de features, MSC, segmentação, mecanismo, ML e exportação.
+- Tooltips de ajuda por passo.
+- Mensagens de foco e acessibilidade.

--- a/ogum-ml-lite/docs/MICROCOPY_en.yaml
+++ b/ogum-ml-lite/docs/MICROCOPY_en.yaml
@@ -1,0 +1,85 @@
+wizard:
+  title: Guided mode
+  intro: Run the full pipeline step by step.
+  actions:
+    previous: Back
+    next: Next
+    run_step: Run step
+    open_artifact: Open artifacts
+  tooltips:
+    data: Upload or select an existing CSV and validate it before preparing.
+    features: Build features from the prepared CSV or reuse a custom file.
+    msc: Run θ/MSC choosing your preferred collapse metric.
+    segments: Compute segmentation and Blaine using fixed or data-driven strategy.
+    mechanism: Analyse mechanism change with τ and R².
+    ml: Train classification or regression models and optionally generate predictions.
+    export: Finish by exporting the report and the session ZIP bundle.
+  steps:
+    data:
+      title: Data
+      description: Select, validate and prepare the base dataset.
+    features:
+      title: Features
+      description: Build global or reprocessed features.
+    msc:
+      title: θ & MSC
+      description: Inspect curve collapse and Ea metrics.
+    segments:
+      title: Segmentation & Blaine
+      description: Generate fixed or data-driven segmentation.
+    mechanism:
+      title: Mechanism
+      description: Mechanism change report per sample.
+    ml:
+      title: ML
+      description: Train models and optionally produce predictions.
+    export:
+      title: Export
+      description: Assemble the final report and ZIP package.
+  focus_hint: Use Tab/Shift+Tab to move and Enter to trigger buttons.
+  blockers:
+    need_prep: '[warn] Generate the prepared CSV before moving on.'
+    need_features: '[warn] Build the features file to continue.'
+    need_theta: '[warn] Run θ/MSC to unlock this step.'
+    need_segments: '[warn] Run segmentation first.'
+    need_mechanism: '[warn] Run mechanism before ML.'
+    need_ml: '[warn] Train a model before exporting.'
+  features:
+    use_prep: Use prep.csv as input
+microcopy:
+  select_csv: Select the CSV
+  upload_csv: Upload CSV
+  validate_data: Validate data
+  run_prep: Prepare data
+  run_features: Generate features
+  run_msc: Run MSC
+  run_segments: Generate segmentation
+  run_mechanism: Run mechanism
+  run_ml_cls: Train classification
+  run_ml_reg: Train regression
+  run_ml_predict: Generate predictions
+  run_export: Build export
+  prep_ready: '[ok] Data prepared'
+  validation_ok: '[ok] Data validated successfully'
+  validation_warn: '[warn] Validation reported warnings'
+  features_ready: '[ok] Features available'
+  msc_ready: '[ok] θ/MSC updated'
+  segments_ready: '[ok] Segmentation saved'
+  mechanism_ready: '[ok] Mechanism report saved'
+  ml_ready: '[ok] ML artifacts generated'
+  predict_ready: '[ok] Predictions ready'
+  export_ready: '[ok] Report and ZIP updated'
+  missing_artifact: '[warn] No artifact available'
+  spinner_prep: Running preparation...
+  spinner_features: Building features...
+  spinner_msc: Running θ/MSC...
+  spinner_segments: Computing segmentation...
+  spinner_mechanism: Computing mechanism...
+  spinner_ml: Training model...
+  spinner_predict: Generating predictions...
+  spinner_export: Assembling export...
+  focus_primary: 'Focus on this step: review results before moving on.'
+  describe_msc: 'MSC: mean curve with ±1σ band.'
+  describe_segments: 'Segments: table with fractions per stage.'
+  describe_mechanism: 'Mechanism: report with τ, R² and detected thresholds.'
+  describe_ml: 'ML: cross-validation metrics per model.'

--- a/ogum-ml-lite/docs/MICROCOPY_pt.yaml
+++ b/ogum-ml-lite/docs/MICROCOPY_pt.yaml
@@ -1,0 +1,85 @@
+wizard:
+  title: Modo guiado
+  intro: Execute o pipeline completo passo a passo.
+  actions:
+    previous: Voltar
+    next: Avançar
+    run_step: Rodar etapa
+    open_artifact: Abrir artefatos
+  tooltips:
+    data: Carregue ou selecione um CSV existente e valide antes de preparar.
+    features: Gere features a partir do CSV preparado ou reaproveite um arquivo custom.
+    msc: Execute θ/MSC escolhendo a métrica de colapso preferida.
+    segments: Calcule segmentação e Blaine; escolha modo fixo ou data-driven.
+    mechanism: Analise mudança de mecanismo com τ e R².
+    ml: Treine modelos de classificação ou regressão e, se quiser, gere predições.
+    export: Finalize exportando relatório e pacote ZIP da sessão.
+  steps:
+    data:
+      title: Dados
+      description: Selecione, valide e prepare o dataset base.
+    features:
+      title: Features
+      description: Construa features globais ou reprocessadas.
+    msc:
+      title: θ & MSC
+      description: Avalie colapso da curva e métricas Ea.
+    segments:
+      title: Segmentação & Blaine
+      description: Gere segmentação fixa ou orientada por dados.
+    mechanism:
+      title: Mecanismo
+      description: Relatório de mudança de mecanismo por amostra.
+    ml:
+      title: ML
+      description: Treine modelos e opcionalmente gere predições.
+    export:
+      title: Exportar
+      description: Monte o relatório final e o pacote ZIP.
+  focus_hint: Use Tab/Shift+Tab para navegar e Enter para acionar botões.
+  blockers:
+    need_prep: '[warn] Gere o CSV preparado antes de avançar.'
+    need_features: '[warn] Gere o arquivo de features para continuar.'
+    need_theta: '[warn] Rode θ/MSC para liberar este passo.'
+    need_segments: '[warn] Execute a segmentação primeiro.'
+    need_mechanism: '[warn] Rode mecanismo antes de treinar ML.'
+    need_ml: '[warn] Treine um modelo antes de exportar.'
+  features:
+    use_prep: Usar prep.csv como entrada
+microcopy:
+  select_csv: Selecione o CSV
+  upload_csv: Enviar CSV
+  validate_data: Validar dados
+  run_prep: Preparar dados
+  run_features: Gerar features
+  run_msc: Executar MSC
+  run_segments: Gerar segmentação
+  run_mechanism: Rodar mecanismo
+  run_ml_cls: Treinar classificação
+  run_ml_reg: Treinar regressão
+  run_ml_predict: Gerar predições
+  run_export: Gerar exportação
+  prep_ready: '[ok] Dados preparados'
+  validation_ok: '[ok] Dados validados com sucesso'
+  validation_warn: '[warn] Validação encontrou avisos'
+  features_ready: '[ok] Features disponíveis'
+  msc_ready: '[ok] θ/MSC atualizado'
+  segments_ready: '[ok] Segmentação salva'
+  mechanism_ready: '[ok] Relatório de mecanismo salvo'
+  ml_ready: '[ok] Artefatos de ML gerados'
+  predict_ready: '[ok] Predições prontas'
+  export_ready: '[ok] Relatório e ZIP atualizados'
+  missing_artifact: '[warn] Nenhum artefato disponível'
+  spinner_prep: Executando preparação...
+  spinner_features: Gerando features...
+  spinner_msc: Executando θ/MSC...
+  spinner_segments: Calculando segmentação...
+  spinner_mechanism: Calculando mecanismo...
+  spinner_ml: Treinando modelo...
+  spinner_predict: Gerando predições...
+  spinner_export: Montando exportação...
+  focus_primary: 'Foco nesta etapa: revise resultados antes de avançar.'
+  describe_msc: 'MSC: curva média com faixa ±1σ.'
+  describe_segments: 'Segmentos: tabela com frações por estágio.'
+  describe_mechanism: 'Mecanismo: relatório com τ, R² e limiares detectados.'
+  describe_ml: 'ML: métricas de validação cruzada por modelo.'

--- a/ogum-ml-lite/tests/test_a11y_utils.py
+++ b/ogum-ml-lite/tests/test_a11y_utils.py
@@ -1,0 +1,28 @@
+"""Tests for accessibility helper functions."""
+
+from __future__ import annotations
+
+from app.design import a11y
+
+
+def test_focus_hint_default() -> None:
+    hint = a11y.focus_hint()
+    assert str(hint) == "Use Tab/Shift+Tab to navigate."
+
+
+def test_focus_hint_custom_message() -> None:
+    hint = a11y.focus_hint("Press Enter to confirm.")
+    assert str(hint) == "Press Enter to confirm."
+
+
+def test_aria_label_injects_help() -> None:
+    payload = a11y.aria_label("Run action")
+    assert payload == {"help": "Run action"}
+
+
+def test_describe_chart_handles_empty_summary() -> None:
+    assert a11y.describe_chart(" ") == "📈 Chart summary unavailable"
+
+
+def test_describe_chart_custom_prefix() -> None:
+    assert a11y.describe_chart("theta curve", prefix="θ") == "θ theta curve"

--- a/ogum-ml-lite/tests/test_i18n_lint.py
+++ b/ogum-ml-lite/tests/test_i18n_lint.py
@@ -1,0 +1,12 @@
+"""Tests for translation catalogue linting."""
+
+from __future__ import annotations
+
+from app.services import i18n_lint
+
+
+def test_locales_have_same_keys() -> None:
+    report = i18n_lint.lint()
+    assert all(
+        not payload["missing"] and not payload["extra"] for payload in report.values()
+    )

--- a/ogum-ml-lite/tests/test_wizard_flow.py
+++ b/ogum-ml-lite/tests/test_wizard_flow.py
@@ -1,0 +1,101 @@
+"""Smoke tests for the guided wizard state machine."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Callable
+
+import pytest
+from app.pages import page_wizard
+
+
+class DummyState:
+    def __init__(self, resolver: Callable[[str], object | None]) -> None:
+        self._resolver = resolver
+
+    def get_artifact(self, key: str) -> object | None:
+        return self._resolver(key)
+
+
+class DummyStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, object] = {}
+
+    def columns(self, sizes):  # pragma: no cover - not used in tests
+        return [
+            SimpleNamespace(
+                button=lambda *_, **__: False, caption=lambda *_, **__: None
+            )
+            for _ in sizes
+        ]
+
+    def caption(self, *_args, **_kwargs) -> None:  # pragma: no cover - noop
+        return None
+
+    def subheader(self, *_args, **_kwargs) -> None:  # pragma: no cover - noop
+        return None
+
+    def markdown(self, *_args, **_kwargs) -> None:  # pragma: no cover - noop
+        return None
+
+    def divider(self) -> None:  # pragma: no cover - noop
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_st = DummyStreamlit()
+    monkeypatch.setattr(page_wizard, "st", dummy_st)
+    monkeypatch.setattr(page_wizard, "state", DummyState(lambda _key: None))
+
+
+def _make_path(exists: bool) -> SimpleNamespace:
+    return SimpleNamespace(exists=lambda: exists)
+
+
+def test_sync_flags_detects_existing_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
+    artifacts = {
+        "prep_csv": _make_path(True),
+        "features_csv": _make_path(True),
+        "theta_table": _make_path(True),
+        "segments": _make_path(True),
+        "mechanism": _make_path(True),
+        "ml_cls": _make_path(True),
+        "export_report": _make_path(True),
+        "session_zip": _make_path(True),
+    }
+    monkeypatch.setattr(
+        page_wizard, "state", DummyState(lambda key: artifacts.get(key))
+    )
+    page_wizard._sync_flags()
+    flags = page_wizard.st.session_state[page_wizard.FLAGS_KEY]
+    assert all(flags.get(step.key) for step in page_wizard.STEPS)
+
+
+def test_flags_do_not_mark_missing_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
+    artifacts = {"prep_csv": _make_path(True), "features_csv": None}
+    monkeypatch.setattr(
+        page_wizard, "state", DummyState(lambda key: artifacts.get(key))
+    )
+    page_wizard._sync_flags()
+    flags = page_wizard.st.session_state[page_wizard.FLAGS_KEY]
+    assert flags.get("data") is True
+    assert flags.get("features") is not True
+
+
+def test_mark_complete_updates_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    page_wizard._mark_complete("data")
+    assert page_wizard._is_complete("data") is True
+    assert page_wizard._is_complete("features") is False
+
+
+def test_step_order_matches_spec() -> None:
+    assert [step.key for step in page_wizard.STEPS] == [
+        "data",
+        "features",
+        "msc",
+        "segments",
+        "mechanism",
+        "ml",
+        "export",
+    ]


### PR DESCRIPTION
## Summary
- add a UX design spec plus microcopy catalogues to document the guided workflows
- introduce a Streamlit wizard page with session-aware navigation, accessibility hints, and reuse of existing CLI services
- expand i18n coverage with lint utilities, link checking, and new accessibility helpers applied across the frontend
- add tests covering the wizard state machine, accessibility helpers, and translation lint parity

## Testing
- ruff check .
- black --check .
- PYTHONPATH=. pytest tests/test_a11y_utils.py tests/test_i18n_lint.py tests/test_wizard_flow.py -q


------
https://chatgpt.com/codex/tasks/task_e_68deabe73bc88327ad9074bcfdfec8a0