### PR TITLE
feat: extend mapping metadata and max-rate segmentation

### DIFF
--- a/ogum-ml-lite/app/config/profiles/cold.yaml
+++ b/ogum-ml-lite/app/config/profiles/cold.yaml
@@ -1,0 +1,5 @@
+technique_profile:
+  name: Cold
+  heating_rate_c_per_min: 5
+  atmosphere: Ambiente controlado
+  notes: Cold sintering assistido por fase líquida a baixa temperatura.

--- a/ogum-ml-lite/app/config/profiles/conventional.yaml
+++ b/ogum-ml-lite/app/config/profiles/conventional.yaml
@@ -4,6 +4,11 @@ columns:
     - time_s
     - temp_C
     - rho_rel
+technique_profile:
+  name: Conventional
+  heating_rate_c_per_min: 10
+  atmosphere: Air
+  notes: Ciclo padrão em forno resistivo com patamar final.
 msc:
   ea_kj:
     - 200

--- a/ogum-ml-lite/app/config/profiles/flash.yaml
+++ b/ogum-ml-lite/app/config/profiles/flash.yaml
@@ -1,0 +1,5 @@
+technique_profile:
+  name: Flash
+  heating_rate_c_per_min: 500
+  atmosphere: Ar/Oxigênio controlado
+  notes: Flash sintering com corrente elétrica assistida e patamar curto.

--- a/ogum-ml-lite/app/config/profiles/fs_uhs.yaml
+++ b/ogum-ml-lite/app/config/profiles/fs_uhs.yaml
@@ -5,6 +5,11 @@ columns:
     - temp_C
     - rho_rel
     - pressure_mpa
+technique_profile:
+  name: UHS
+  heating_rate_c_per_min: 50
+  atmosphere: Inerte
+  notes: Ultra-high speed sintering com pressão uniaxial moderada.
 msc:
   ea_kj:
     - 150

--- a/ogum-ml-lite/app/config/profiles/heating_only.yaml
+++ b/ogum-ml-lite/app/config/profiles/heating_only.yaml
@@ -1,0 +1,5 @@
+technique_profile:
+  name: Heating-Only
+  heating_rate_c_per_min: 15
+  atmosphere: Ar/N2
+  notes: Perfil sem pressão, apenas aquecimento com rampa simples.

--- a/ogum-ml-lite/app/config/profiles/outro.yaml
+++ b/ogum-ml-lite/app/config/profiles/outro.yaml
@@ -1,0 +1,5 @@
+technique_profile:
+  name: Outro
+  heating_rate_c_per_min: null
+  atmosphere: Desconhecida
+  notes: Utilize tech_comment para detalhar a rota personalizada.

--- a/ogum-ml-lite/app/config/profiles/sps.yaml
+++ b/ogum-ml-lite/app/config/profiles/sps.yaml
@@ -5,6 +5,11 @@ columns:
     - temp_C
     - rho_rel
     - current_a
+technique_profile:
+  name: SPS
+  heating_rate_c_per_min: 100
+  atmosphere: Vacuum/Ar
+  notes: Ciclo em prensa a plasma com controle de corrente pulsada.
 msc:
   ea_kj:
     - 180

--- a/ogum-ml-lite/app/config/profiles/two_step.yaml
+++ b/ogum-ml-lite/app/config/profiles/two_step.yaml
@@ -1,0 +1,5 @@
+technique_profile:
+  name: Two-Step
+  heating_rate_c_per_min: 20
+  atmosphere: Ar
+  notes: Duas rampas com patamar intermediário para controle de grão.


### PR DESCRIPTION
## Summary
- extend `read_table` and the column mapping pipeline to support TXT files, canonical response columns, per-user metadata, and technique presets
- add response normalisation helpers and CLI flags for manual composition/technique defaults, response conversion, and metadata capture
- implement a max-rate segmentation mode, integrate Ea range scanning with optional auto-selection, and ship technique profile YAMLs for new sintering routes

## Testing
- pytest -q *(fails: ModuleNotFoundError for optional app/ogum_lite packages during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68dedb9d97f483278e9993976c5079a1