### PR TITLE
Add execution comparison tooling and UI integrations

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -198,6 +198,52 @@ com aviso `[skip]`.
   diretórios individuais `workspace/jobs/<job_id>/` para logs e artefatos.
 - **Agendamento**: use `--at "2025-01-10 12:00"` para agendar execuções
   futuras.
+
+## Fase 13 — Comparador de Execuções
+
+O módulo de comparação facilita auditorias entre execuções do Ogum-ML,
+considerando presets, MSC, segmentos, mecanismo e artefatos de ML.
+
+### CLI dedicada
+
+Compare duas execuções (diretórios ou export ZIP):
+
+```bash
+python -m ogum_lite.cli compare runs \
+  --a artifacts/bench_cls/run_A \
+  --b artifacts/bench_cls/run_B \
+  --outdir artifacts/compare_cls_A_vs_B
+```
+
+Para matrizes (referência × candidatos) com relatórios individuais ref vs
+cada candidato:
+
+```bash
+python -m ogum_lite.cli compare matrix \
+  --ref artifacts/bench_reg/run_ref \
+  --candidates artifacts/bench_reg/run_1 artifacts/bench_reg/run_2 \
+  --outdir artifacts/compare_reg_matrix
+```
+
+Resultados:
+
+- `compare_summary.json` (manifest + deltas consolidados).
+- `report.html` com gráficos inline (base64) e destaques principais.
+- `report.xlsx` (abas Summary, Diff-Presets, Diff-ML, etc.).
+- Para matriz: `ranking.csv` + `matrix.html` e subpastas com relatórios
+  individuais.
+
+> 💡 Boas práticas: mantenha `report.html`/`report.xlsx` ao lado de cada run e
+> use nomes descritivos para `--outdir` (ex.: `compare_cls_2025-01_vs_02`).
+
+### Página Streamlit “Compare Runs”
+
+- Acesse via menu principal após abrir `streamlit run app/streamlit_app.py`.
+- Selecione o modo **Runs** (A × B) ou **Matrix** (referência vs lista).
+- Informe caminhos/diretórios do workspace ou faça upload prévio do ZIP.
+- Clique em **Compare** / **Build matrix** para gerar os relatórios.
+- Baixe os arquivos diretamente pelos botões exibidos na página ou visualize o
+  HTML inline.
 - **Monitoramento unificado**: Streamlit ganha a página "Jobs Monitor" e o
   Gradio recebe a aba "Jobs" para acompanhar execuções, visualizar logs e
   cancelar jobs.

--- a/ogum-ml-lite/app/pages/__init__.py
+++ b/ogum-ml-lite/app/pages/__init__.py
@@ -1,6 +1,7 @@
 """Page registry for the Streamlit application."""
 
 from . import (
+    page_compare,
     page_export,
     page_features,
     page_jobs,
@@ -13,6 +14,7 @@ from . import (
 )
 
 __all__ = [
+    "page_compare",
     "page_export",
     "page_features",
     "page_mechanism",

--- a/ogum-ml-lite/app/pages/page_compare.py
+++ b/ogum-ml-lite/app/pages/page_compare.py
@@ -1,0 +1,92 @@
+"""Streamlit page for comparing Ogum-ML runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+import streamlit.components.v1 as components
+from ogum_lite.compare.cli_compare import cmd_compare_matrix, cmd_compare_runs
+
+from ..services import state
+
+
+def _render_download(path: Path, label: str) -> None:
+    if path.exists():
+        st.download_button(
+            label=label,
+            data=path.read_bytes(),
+            file_name=path.name,
+        )
+
+
+def render(_) -> None:
+    """Render the comparison utilities page."""
+
+    st.subheader("Compare Runs")
+    workspace = state.get_workspace()
+    default_dir = Path(workspace.path) if workspace else Path.cwd()
+
+    mode = st.selectbox("Mode", ("Runs", "Matrix"))
+
+    if mode == "Runs":
+        col_a, col_b = st.columns(2)
+        with col_a:
+            path_a = st.text_input("Run A", value=str(default_dir))
+        with col_b:
+            path_b = st.text_input("Run B", value=str(default_dir))
+        outdir = Path(
+            st.text_input("Output directory", value=str(default_dir / "compare_runs"))
+        )
+        if st.button("Compare"):
+            with st.spinner("Comparing runs..."):
+                cmd_compare_runs(
+                    argparse.Namespace(a=path_a, b=path_b, outdir=str(outdir))
+                )
+            st.success("Comparison finished")
+        summary_path = outdir / "compare_summary.json"
+        if summary_path.exists():
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+            summary_rows = data.get("diffs", {}).get("summary", {}).get("kpis", [])
+            if summary_rows:
+                st.dataframe(pd.DataFrame(summary_rows))
+            html_path = Path(data.get("html", outdir / "report.html"))
+            xlsx_path = Path(data.get("xlsx", outdir / "report.xlsx"))
+            _render_download(html_path, f"HTML · {html_path.name}")
+            _render_download(xlsx_path, f"XLSX · {xlsx_path.name}")
+            if html_path.exists():
+                components.v1.html(
+                    html_path.read_text(encoding="utf-8"),
+                    height=400,
+                    scrolling=True,
+                )
+    else:
+        path_ref = st.text_input("Reference run", value=str(default_dir))
+        candidates_raw = st.text_area(
+            "Candidates (one per line)", value=str(default_dir)
+        )
+        candidates = [
+            line.strip() for line in candidates_raw.splitlines() if line.strip()
+        ]
+        outdir = Path(
+            st.text_input("Output directory", value=str(default_dir / "compare_matrix"))
+        )
+        if st.button("Build matrix"):
+            with st.spinner("Building matrix..."):
+                cmd_compare_matrix(
+                    argparse.Namespace(
+                        ref=path_ref, candidates=candidates, outdir=str(outdir)
+                    )
+                )
+            st.success("Matrix ready")
+        ranking_path = outdir / "ranking.csv"
+        if ranking_path.exists():
+            ranking = pd.read_csv(ranking_path)
+            st.dataframe(ranking)
+            _render_download(outdir / "matrix.html", "HTML · matrix.html")
+
+
+__all__ = ["render"]

--- a/ogum-ml-lite/ogum_lite/cli.py
+++ b/ogum-ml-lite/ogum_lite/cli.py
@@ -28,6 +28,7 @@ from sklearn.metrics import (
 
 from . import scheduler
 from .arrhenius import arrhenius_lnT_dy_dt_vs_invT, fit_arrhenius_global
+from .compare.cli_compare import build_compare_parser
 from .exporters import export_onnx, export_xlsx
 from .features import arrhenius_feature_table, build_feature_store, build_feature_table
 from .io_mapping import (
@@ -1736,6 +1737,9 @@ def cmd_jobs_cancel(args: argparse.Namespace) -> None:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Ogum ML Lite CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_compare = subparsers.add_parser("compare", help="Comparador de execuções")
+    build_compare_parser(parser_compare)
 
     parser_jobs = subparsers.add_parser("jobs", help="Scheduler e monitor de jobs")
     parser_jobs.add_argument(

--- a/ogum-ml-lite/ogum_lite/compare/__init__.py
+++ b/ogum-ml-lite/ogum_lite/compare/__init__.py
@@ -1,0 +1,25 @@
+"""Utilities for comparing Ogum-ML runs."""
+
+from .diff_core import (
+    compose_diff_summary,
+    diff_mechanism,
+    diff_ml,
+    diff_msc,
+    diff_presets,
+    diff_segments,
+)
+from .loaders import find_run_root, scan_run
+from .reporters import export_xlsx_compare, render_html_compare
+
+__all__ = [
+    "find_run_root",
+    "scan_run",
+    "diff_presets",
+    "diff_msc",
+    "diff_segments",
+    "diff_mechanism",
+    "diff_ml",
+    "compose_diff_summary",
+    "render_html_compare",
+    "export_xlsx_compare",
+]

--- a/ogum-ml-lite/ogum_lite/compare/cli_compare.py
+++ b/ogum-ml-lite/ogum_lite/compare/cli_compare.py
@@ -1,0 +1,214 @@
+"""Command line entry-points for the comparison toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from .diff_core import (
+    compose_diff_summary,
+    diff_mechanism,
+    diff_ml,
+    diff_msc,
+    diff_presets,
+    diff_segments,
+)
+from .loaders import find_run_root, load_json, load_yaml, scan_run
+from .reporters import export_xlsx_compare, render_html_compare
+
+
+@dataclass
+class RunArtifacts:
+    """Container with resolved paths for a run."""
+
+    name: str
+    manifest: dict[str, Any]
+    preset: dict[str, Any] | None
+
+
+def _load_run(path: Path) -> RunArtifacts:
+    root = find_run_root(path)
+    manifest = scan_run(root)
+    preset = load_yaml(manifest.get("presets")) or load_json(manifest.get("presets"))
+    return RunArtifacts(name=root.name, manifest=manifest, preset=preset)
+
+
+def _serialisable(payload: dict[str, Any]) -> dict[str, Any]:
+    def _convert(value: Any) -> Any:
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, dict):
+            return {k: _convert(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_convert(item) for item in value]
+        return value
+
+    return _convert(payload)
+
+
+def _diff_runs(run_a: RunArtifacts, run_b: RunArtifacts) -> dict[str, Any]:
+    msc_diff = diff_msc(run_a.manifest.get("msc_csv"), run_b.manifest.get("msc_csv"))
+    segments_diff = diff_segments(
+        run_a.manifest.get("segments_table"), run_b.manifest.get("segments_table")
+    )
+    mechanism_diff = diff_mechanism(
+        run_a.manifest.get("mechanism_csv"), run_b.manifest.get("mechanism_csv")
+    )
+    ml_diff = diff_ml(
+        run_a.manifest.get("ml_model_card"),
+        run_b.manifest.get("ml_model_card"),
+        run_a.manifest.get("ml_cv_metrics"),
+        run_b.manifest.get("ml_cv_metrics"),
+    )
+    presets_diff = diff_presets(run_a.preset, run_b.preset)
+    summary = compose_diff_summary(
+        presets=presets_diff,
+        msc=msc_diff,
+        segments=segments_diff,
+        mechanism=mechanism_diff,
+        ml=ml_diff,
+    )
+    return {
+        "summary": summary,
+        "presets": presets_diff,
+        "msc": msc_diff,
+        "segments": segments_diff,
+        "mechanism": mechanism_diff,
+        "ml": ml_diff,
+    }
+
+
+def cmd_compare_runs(args: argparse.Namespace) -> None:
+    run_a = _load_run(Path(args.a))
+    run_b = _load_run(Path(args.b))
+    diffs = _diff_runs(run_a, run_b)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    summary_rows = diffs["summary"].get("kpis", [])
+    summary_df = pd.DataFrame(summary_rows)
+    if summary_df.empty:
+        summary_df = pd.DataFrame([{"metric": "n/a"}])
+
+    tables: dict[str, pd.DataFrame] = {}
+    if diffs["presets"].get("changed"):
+        tables["Presets"] = pd.DataFrame(
+            [
+                {"key": key, "a": value["a"], "b": value["b"]}
+                for key, value in diffs["presets"]["changed"].items()
+            ]
+        )
+    if diffs["segments"].get("changed"):
+        rows = []
+        for key, value in diffs["segments"]["changed"].items():
+            for metric, payload in value.items():
+                rows.append(
+                    {
+                        "segment": "×".join(map(str, key)),
+                        "metric": metric,
+                        **payload,
+                    }
+                )
+        tables["Segments"] = pd.DataFrame(rows)
+    if diffs["ml"].get("metrics"):
+        tables["ML"] = pd.DataFrame(diffs["ml"]["metrics"].values())
+
+    images: dict[str, bytes] = {}
+    for label in ("ml_confusion", "ml_scatter", "msc_plot"):
+        path = run_a.manifest.get(label)
+        if path and Path(path).exists():
+            images[f"A:{label}"] = Path(path).read_bytes()
+        path = run_b.manifest.get(label)
+        if path and Path(path).exists():
+            images[f"B:{label}"] = Path(path).read_bytes()
+    if not images:
+        images = None
+
+    html_path = render_html_compare(
+        outdir, {"runs": [run_a.name, run_b.name]}, {**diffs}, images=images
+    )
+    xlsx_path = export_xlsx_compare(
+        outdir / "report.xlsx", summary=summary_df, tables=tables, images=images
+    )
+
+    payload = {
+        "runs": {"a": run_a.manifest, "b": run_b.manifest},
+        "diffs": diffs,
+        "html": html_path,
+        "xlsx": xlsx_path,
+    }
+    (outdir / "compare_summary.json").write_text(
+        json.dumps(_serialisable(payload), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def cmd_compare_matrix(args: argparse.Namespace) -> None:
+    ref_run = _load_run(Path(args.ref))
+    candidates = [_load_run(Path(path)) for path in args.candidates]
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+    for candidate in candidates:
+        diffs = _diff_runs(ref_run, candidate)
+        summary_rows = diffs["summary"].get("kpis", [])
+        best_metric = None
+        if summary_rows:
+            best_metric = min(summary_rows, key=lambda item: item.get("delta", 0.0))
+        row = {
+            "candidate": candidate.name,
+            "alerts": "; ".join(diffs["summary"].get("alerts", [])),
+        }
+        if best_metric:
+            row.update(
+                {
+                    "metric": best_metric.get("metric"),
+                    "delta": best_metric.get("delta"),
+                }
+            )
+        rows.append(row)
+
+        target_dir = outdir / f"{ref_run.name}_vs_{candidate.name}"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        cmd_compare_runs(
+            argparse.Namespace(
+                a=args.ref,
+                b=str(candidate.manifest["root"]),
+                outdir=str(target_dir),
+            )
+        )
+
+    ranking = pd.DataFrame(rows)
+    ranking_path = outdir / "ranking.csv"
+    ranking.to_csv(ranking_path, index=False)
+
+    html = ranking.to_html(index=False)
+    (outdir / "matrix.html").write_text(html, encoding="utf-8")
+
+
+def build_compare_parser(parser: argparse.ArgumentParser) -> None:
+    subparsers = parser.add_subparsers(dest="compare_command", required=True)
+
+    runs_parser = subparsers.add_parser("runs", help="Compare two runs")
+    runs_parser.add_argument("--a", required=True, help="Run A path or zip")
+    runs_parser.add_argument("--b", required=True, help="Run B path or zip")
+    runs_parser.add_argument("--outdir", required=True, help="Output directory")
+    runs_parser.set_defaults(func=cmd_compare_runs)
+
+    matrix_parser = subparsers.add_parser("matrix", help="Reference vs candidates")
+    matrix_parser.add_argument("--ref", required=True, help="Reference run path")
+    matrix_parser.add_argument(
+        "--candidates", nargs="+", required=True, help="Candidate run paths"
+    )
+    matrix_parser.add_argument("--outdir", required=True, help="Directory for outputs")
+    matrix_parser.set_defaults(func=cmd_compare_matrix)
+
+
+__all__ = ["build_compare_parser", "cmd_compare_runs", "cmd_compare_matrix"]

--- a/ogum-ml-lite/ogum_lite/compare/diff_core.py
+++ b/ogum-ml-lite/ogum_lite/compare/diff_core.py
@@ -1,0 +1,342 @@
+"""Semantic diff helpers for Ogum-ML artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+
+from .loaders import load_csv, load_json, load_yaml
+
+
+@dataclass(slots=True)
+class MetricDelta:
+    """Container describing the delta between metrics."""
+
+    metric: str
+    a: float | None
+    b: float | None
+    delta: float | None
+    delta_pct: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric,
+            "a": self.a,
+            "b": self.b,
+            "delta": self.delta,
+            "delta_pct": self.delta_pct,
+        }
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        return float(str(value))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def diff_presets(a: dict[str, Any] | None, b: dict[str, Any] | None) -> dict[str, Any]:
+    """Compute differences between two preset dictionaries."""
+
+    result: dict[str, Any] = {
+        "missing": {"a": a is None, "b": b is None},
+        "added": {},
+        "removed": {},
+        "changed": {},
+        "lists": {},
+    }
+    if a is None or b is None:
+        return result
+
+    keys_a = set(a.keys())
+    keys_b = set(b.keys())
+    for key in sorted(keys_b - keys_a):
+        result["added"][key] = b[key]
+    for key in sorted(keys_a - keys_b):
+        result["removed"][key] = a[key]
+
+    for key in sorted(keys_a & keys_b):
+        left = a[key]
+        right = b[key]
+        if isinstance(left, list) and isinstance(right, list):
+            left_set = list(dict.fromkeys(left))
+            right_set = list(dict.fromkeys(right))
+            result["lists"][key] = {
+                "only_a": [item for item in left_set if item not in right_set],
+                "only_b": [item for item in right_set if item not in left_set],
+                "shared": [item for item in left_set if item in right_set],
+            }
+            if result["lists"][key]["only_a"] or result["lists"][key]["only_b"]:
+                result["changed"][key] = {"a": left, "b": right}
+            continue
+        if left != right:
+            result["changed"][key] = {"a": left, "b": right}
+    return result
+
+
+def _extract_metric(row: pd.Series, candidates: Iterable[str]) -> float | None:
+    for name in candidates:
+        if name in row:
+            value = _safe_float(row[name])
+            if value is not None:
+                return value
+    return None
+
+
+def diff_msc(a_csv: Path | None, b_csv: Path | None) -> dict[str, Any]:
+    """Compare MSC summaries produced by two runs."""
+
+    df_a = load_csv(a_csv)
+    df_b = load_csv(b_csv)
+    result: dict[str, Any] = {
+        "missing": {"a": df_a is None, "b": df_b is None},
+        "metrics": {},
+        "curve": None,
+    }
+    if df_a is None or df_b is None:
+        return result
+
+    row_a = df_a.iloc[0]
+    row_b = df_b.iloc[0]
+
+    for metric, aliases in {
+        "mse_global": ["mse_global", "mse"],
+        "mse_segmented": ["mse_segmented", "mse_seg"],
+    }.items():
+        value_a = _extract_metric(row_a, aliases)
+        value_b = _extract_metric(row_b, aliases)
+        delta = None
+        delta_pct = None
+        if value_a is not None and value_b is not None:
+            delta = value_b - value_a
+            if value_a != 0:
+                delta_pct = delta / value_a
+        result["metrics"][metric] = MetricDelta(
+            metric=metric,
+            a=value_a,
+            b=value_b,
+            delta=delta,
+            delta_pct=delta_pct,
+        ).to_dict()
+
+    if {
+        "theta_norm",
+        "prediction",
+        "target",
+    }.issubset(df_a.columns) and {
+        "theta_norm",
+        "prediction",
+        "target",
+    }.issubset(df_b.columns):
+        merged = df_a.merge(df_b, on="theta_norm", suffixes=("_a", "_b"))
+        if not merged.empty:
+            merged["delta"] = (merged["prediction_b"] - merged["prediction_a"]).abs()
+            result["curve"] = {
+                "mean_abs_delta": float(merged["delta"].mean()),
+                "n_points": int(len(merged)),
+            }
+    return result
+
+
+def diff_segments(a_table: Path | None, b_table: Path | None) -> dict[str, Any]:
+    """Compare per-segment metrics."""
+
+    df_a = load_csv(a_table)
+    df_b = load_csv(b_table)
+    result: dict[str, Any] = {
+        "missing": {"a": df_a is None, "b": df_b is None},
+        "changed": {},
+    }
+    if df_a is None or df_b is None:
+        return result
+
+    key_cols = [
+        col
+        for col in ("sample_id", "segment_id")
+        if col in df_a.columns and col in df_b.columns
+    ]
+    if not key_cols:
+        return result
+    merged = df_a.merge(df_b, on=key_cols, suffixes=("_a", "_b"))
+    metrics = ["n_est", "mse", "r2"]
+    for _, row in merged.iterrows():
+        key = tuple(row[col] for col in key_cols)
+        entry: dict[str, Any] = {}
+        for metric in metrics:
+            col_a = f"{metric}_a"
+            col_b = f"{metric}_b"
+            if col_a in row and col_b in row:
+                value_a = _safe_float(row[col_a])
+                value_b = _safe_float(row[col_b])
+                if value_a != value_b:
+                    entry[metric] = {
+                        "a": value_a,
+                        "b": value_b,
+                        "delta": (
+                            None
+                            if value_a is None or value_b is None
+                            else value_b - value_a
+                        ),
+                    }
+        if entry:
+            result["changed"][key] = entry
+    return result
+
+
+def diff_mechanism(a_mech: Path | None, b_mech: Path | None) -> dict[str, Any]:
+    """Compare mechanism change detection outputs."""
+
+    df_a = load_csv(a_mech)
+    df_b = load_csv(b_mech)
+    result: dict[str, Any] = {
+        "missing": {"a": df_a is None, "b": df_b is None},
+        "changed": {},
+    }
+    if df_a is None or df_b is None:
+        return result
+
+    key_cols = [
+        col for col in ("sample_id",) if col in df_a.columns and col in df_b.columns
+    ]
+    if not key_cols:
+        return result
+    merged = df_a.merge(df_b, on=key_cols, suffixes=("_a", "_b"))
+    metrics = ["has_change", "tau", "bic", "aic"]
+    for _, row in merged.iterrows():
+        key = tuple(row[col] for col in key_cols)
+        entry: dict[str, Any] = {}
+        for metric in metrics:
+            col_a = f"{metric}_a"
+            col_b = f"{metric}_b"
+            if col_a in row and col_b in row:
+                value_a = row[col_a]
+                value_b = row[col_b]
+                if value_a != value_b:
+                    entry[metric] = {
+                        "a": value_a,
+                        "b": value_b,
+                    }
+        if entry:
+            result["changed"][key] = entry
+    return result
+
+
+def diff_ml(
+    a_model_card: Path | None,
+    b_model_card: Path | None,
+    a_cv: Path | None,
+    b_cv: Path | None,
+) -> dict[str, Any]:
+    """Compare ML model metadata and metrics."""
+
+    card_a = load_json(a_model_card) or load_yaml(a_model_card)
+    card_b = load_json(b_model_card) or load_yaml(b_model_card)
+    cv_a = load_json(a_cv)
+    cv_b = load_json(b_cv)
+
+    result: dict[str, Any] = {
+        "missing": {
+            "card_a": card_a is None,
+            "card_b": card_b is None,
+            "cv_a": cv_a is None,
+            "cv_b": cv_b is None,
+        },
+        "algorithm": None,
+        "hyperparameters": {},
+        "metrics": {},
+    }
+
+    if card_a and card_b:
+        algo_a = card_a.get("algorithm") or card_a.get("estimator")
+        algo_b = card_b.get("algorithm") or card_b.get("estimator")
+        if algo_a != algo_b:
+            result["algorithm"] = {"a": algo_a, "b": algo_b}
+        params_a = card_a.get("hyperparameters", {}) or {}
+        params_b = card_b.get("hyperparameters", {}) or {}
+        keys = set(params_a) | set(params_b)
+        for key in sorted(keys):
+            if params_a.get(key) != params_b.get(key):
+                result["hyperparameters"][key] = {
+                    "a": params_a.get(key),
+                    "b": params_b.get(key),
+                }
+
+    metric_aliases = {
+        "accuracy": ["accuracy", "acc"],
+        "f1": ["f1", "f1_score"],
+        "mae": ["mae", "mean_absolute_error"],
+        "rmse": ["rmse", "root_mean_squared_error", "mse"],
+    }
+    if isinstance(cv_a, dict) and isinstance(cv_b, dict):
+        for metric, aliases in metric_aliases.items():
+            value_a = None
+            value_b = None
+            for alias in aliases:
+                if alias in cv_a:
+                    value_a = _safe_float(cv_a[alias])
+                if alias in cv_b:
+                    value_b = _safe_float(cv_b[alias])
+            if value_a is not None or value_b is not None:
+                delta = None
+                delta_pct = None
+                if value_a is not None and value_b is not None:
+                    delta = value_b - value_a
+                    if value_a != 0:
+                        delta_pct = delta / value_a
+                result["metrics"][metric] = MetricDelta(
+                    metric=metric,
+                    a=value_a,
+                    b=value_b,
+                    delta=delta,
+                    delta_pct=delta_pct,
+                ).to_dict()
+    return result
+
+
+def compose_diff_summary(
+    *,
+    presets: dict[str, Any] | None = None,
+    msc: dict[str, Any] | None = None,
+    segments: dict[str, Any] | None = None,
+    mechanism: dict[str, Any] | None = None,
+    ml: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a consolidated summary of the diffs."""
+
+    summary: dict[str, Any] = {"kpis": []}
+
+    for container in (msc or {}).get("metrics", {}).values():
+        summary["kpis"].append(container)
+
+    for container in (ml or {}).get("metrics", {}).values():
+        summary["kpis"].append(container)
+
+    summary["kpis"].sort(key=lambda item: item.get("metric", ""))
+
+    summary["alerts"] = []
+    if presets:
+        if presets.get("added") or presets.get("removed"):
+            summary["alerts"].append("Preset keys diverged")
+    if segments and segments.get("changed"):
+        summary["alerts"].append("Segments changed")
+    if mechanism and mechanism.get("changed"):
+        summary["alerts"].append("Mechanism detection differs")
+
+    return summary
+
+
+__all__ = [
+    "diff_presets",
+    "diff_msc",
+    "diff_segments",
+    "diff_mechanism",
+    "diff_ml",
+    "compose_diff_summary",
+]

--- a/ogum-ml-lite/ogum_lite/compare/loaders.py
+++ b/ogum-ml-lite/ogum_lite/compare/loaders.py
@@ -1,0 +1,138 @@
+"""Discovery and parsing helpers for Ogum-ML run artifacts."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+import yaml
+
+
+def _extract_zip(source: Path) -> Path:
+    """Extract *source* zip file into a temporary directory and return the root."""
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="ogum_compare_"))
+    with zipfile.ZipFile(source) as zf:
+        zf.extractall(temp_dir)
+    # Attempt to identify a single root folder inside the archive; otherwise
+    # use temp_dir.
+    candidates = [p for p in temp_dir.iterdir() if p.is_dir()]
+    if len(candidates) == 1:
+        return candidates[0]
+    return temp_dir
+
+
+def find_run_root(path: Path) -> Path:
+    """Return the directory that contains a run manifest.
+
+    Parameters
+    ----------
+    path:
+        Directory or zip file pointing to an Ogum-ML run.
+    """
+
+    path = Path(path)
+    if path.is_dir():
+        return path
+    if path.is_file() and path.suffix.lower() == ".zip":
+        return _extract_zip(path)
+    raise FileNotFoundError(f"Unsupported run path: {path}")
+
+
+def _first_existing(root: Path, names: Iterable[str]) -> Path | None:
+    for name in names:
+        candidate = root / name
+        if candidate.exists():
+            return candidate
+    for name in names:
+        matches = list(root.rglob(name))
+        if matches:
+            return matches[0]
+    return None
+
+
+def scan_run(root: Path) -> dict[str, Any]:
+    """Return a manifest for the run located at *root*.
+
+    The manifest contains best-effort pointers to relevant artifacts.
+    Missing entries are reported as ``None`` so callers can handle
+    incomplete runs gracefully.
+    """
+
+    root = Path(root)
+    manifest: dict[str, Any] = {"root": root}
+
+    manifest["presets"] = _first_existing(root, ["preset.yaml", "presets.yaml"])
+
+    manifest["msc_csv"] = _first_existing(root, ["msc.csv"])
+    manifest["msc_plot"] = _first_existing(root, ["msc.png", "msc_plot.png"])
+    manifest["msc_theta_zip"] = _first_existing(root, ["theta.zip", "theta_csv.zip"])
+
+    manifest["segments_json"] = _first_existing(root, ["segments.json"])
+    manifest["segments_table"] = _first_existing(
+        root, ["n_segments.csv", "segments.csv"]
+    )
+
+    manifest["mechanism_csv"] = _first_existing(
+        root, ["mechanism.csv", "mech_report.csv"]
+    )
+
+    manifest["ml_model_card"] = _first_existing(root, ["model_card.json"])
+    manifest["ml_cv_metrics"] = _first_existing(root, ["cv_metrics.json"])
+    manifest["ml_features"] = _first_existing(root, ["feature_cols.json"])
+    manifest["ml_classifier"] = _first_existing(root, ["classifier.joblib"])
+    manifest["ml_regressor"] = _first_existing(root, ["regressor.joblib"])
+    manifest["ml_confusion"] = _first_existing(root, ["confusion.png"])
+    manifest["ml_scatter"] = _first_existing(root, ["scatter.png"])
+
+    manifest["summary_html"] = _first_existing(root, ["report.html", "summary.html"])
+    manifest["summary_xlsx"] = _first_existing(root, ["report.xlsx", "summary.xlsx"])
+
+    manifest["run_log"] = _first_existing(root, ["run_log.jsonl"])
+    manifest["telemetry"] = _first_existing(root, ["telemetry.jsonl"])
+
+    return manifest
+
+
+def load_json(path: Path | None) -> dict[str, Any] | None:
+    """Read a JSON file if available."""
+
+    if path is None or not Path(path).exists():
+        return None
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_yaml(path: Path | None) -> dict[str, Any] | None:
+    """Read a YAML file if available."""
+
+    if path is None or not Path(path).exists():
+        return None
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError("Expected YAML document to be a mapping")
+    return data
+
+
+def load_csv(path: Path | None) -> pd.DataFrame | None:
+    """Read a CSV file into a :class:`pandas.DataFrame` if the file exists."""
+
+    if path is None or not Path(path).exists():
+        return None
+    return pd.read_csv(path)
+
+
+__all__ = [
+    "find_run_root",
+    "scan_run",
+    "load_json",
+    "load_yaml",
+    "load_csv",
+]

--- a/ogum-ml-lite/ogum_lite/compare/reporters.py
+++ b/ogum-ml-lite/ogum_lite/compare/reporters.py
@@ -1,0 +1,105 @@
+"""Report generation helpers for the comparison module."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def _ensure_dir(path: Path) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def render_html_compare(
+    outdir: Path,
+    meta: dict[str, Any],
+    diffs: dict[str, Any],
+    images: dict[str, bytes] | None = None,
+) -> Path:
+    """Render a standalone HTML comparison report."""
+
+    _ensure_dir(outdir)
+    html_path = Path(outdir) / "report.html"
+
+    runs = meta.get("runs", []) if isinstance(meta, dict) else []
+    title = "Ogum-ML · Run comparison"
+    if runs:
+        title += " — " + " vs ".join(map(str, runs))
+    sections: list[str] = [f"<h1>{title}</h1>"]
+    summary_rows = diffs.get("summary", {}).get("kpis", [])
+    if summary_rows:
+        summary_df = pd.DataFrame(summary_rows)
+        sections.append("<h2>Summary</h2>")
+        sections.append(summary_df.to_html(index=False, escape=False))
+    alerts = diffs.get("summary", {}).get("alerts", [])
+    if alerts:
+        sections.append("<h3>Alerts</h3>")
+        items = "".join(f"<li>{alert}</li>" for alert in alerts)
+        sections.append(f"<ul>{items}</ul>")
+
+    for name in ("presets", "msc", "segments", "mechanism", "ml"):
+        payload = diffs.get(name)
+        sections.append(f"<h2>{name.title()}</h2>")
+        if payload:
+            sections.append(
+                f"<pre>{json.dumps(payload, indent=2, ensure_ascii=False)}</pre>"
+            )
+        else:
+            sections.append("<p>No data.</p>")
+
+    if images:
+        for label, content in images.items():
+            b64 = base64.b64encode(content).decode("ascii")
+            tag = (
+                f"<h3>{label}</h3>"
+                f"<img alt='{label}' src='data:image/png;base64,{b64}' />"
+            )
+            sections.append(tag)
+
+    html = "\n".join(sections)
+    html_path.write_text(html, encoding="utf-8")
+    return html_path
+
+
+def export_xlsx_compare(
+    out_path: Path,
+    *,
+    summary: pd.DataFrame,
+    tables: dict[str, pd.DataFrame],
+    images: dict[str, bytes] | None = None,
+) -> Path:
+    """Export comparison results to an XLSX workbook."""
+
+    out_path = Path(out_path)
+    _ensure_dir(out_path.parent)
+
+    def _write_workbook(writer: pd.ExcelWriter) -> None:
+        summary.to_excel(writer, sheet_name="Summary", index=False)
+        for name, table in tables.items():
+            sheet = f"Diff-{name[:25]}"
+            table.to_excel(writer, sheet_name=sheet, index=False)
+        if images:
+            workbook = writer.book
+            for idx, (label, payload) in enumerate(images.items()):
+                sheet_name = f"Img{idx+1}"
+                worksheet = workbook.add_worksheet(sheet_name)
+                writer.sheets[sheet_name] = worksheet
+                worksheet.write(0, 0, label)
+                image_data = io.BytesIO(payload)
+                worksheet.insert_image(1, 0, f"{label}.png", {"image_data": image_data})
+
+    try:
+        with pd.ExcelWriter(out_path, engine="xlsxwriter") as writer:
+            _write_workbook(writer)
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        with pd.ExcelWriter(out_path) as writer:
+            _write_workbook(writer)
+    return out_path
+
+
+__all__ = ["render_html_compare", "export_xlsx_compare"]

--- a/ogum-ml-lite/tests/test_compare_diff.py
+++ b/ogum-ml-lite/tests/test_compare_diff.py
@@ -1,0 +1,139 @@
+"""Tests for semantic diff helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+from ogum_lite.compare import diff_core
+
+
+def _write_csv(path: Path, data: pd.DataFrame) -> None:
+    data.to_csv(path, index=False)
+
+
+def test_diff_presets_detects_changes() -> None:
+    left = {"ea": [1, 2], "profile": "alpha"}
+    right = {"ea": [2, 3], "profile": "beta", "new": 1}
+    diff = diff_core.diff_presets(left, right)
+    assert "profile" in diff["changed"]
+    assert diff["added"] == {"new": 1}
+    assert diff["lists"]["ea"]["only_a"] == [1]
+
+
+def test_diff_msc_metrics(tmp_path: Path) -> None:
+    a_csv = tmp_path / "msc_a.csv"
+    b_csv = tmp_path / "msc_b.csv"
+    _write_csv(
+        a_csv,
+        pd.DataFrame(
+            {
+                "mse_global": [1.0, 1.0],
+                "mse_segmented": [0.5, 0.5],
+                "theta_norm": [0.0, 1.0],
+                "prediction": [0.1, 0.2],
+                "target": [0.1, 0.2],
+            }
+        ),
+    )
+    _write_csv(
+        b_csv,
+        pd.DataFrame(
+            {
+                "mse_global": [0.8, 0.8],
+                "mse_segmented": [0.4, 0.4],
+                "theta_norm": [0.0, 1.0],
+                "prediction": [0.2, 0.3],
+                "target": [0.1, 0.2],
+            }
+        ),
+    )
+    diff = diff_core.diff_msc(a_csv, b_csv)
+    assert diff["metrics"]["mse_global"]["delta"] == -0.19999999999999996
+    assert diff["curve"]["n_points"] == 2
+
+
+def test_diff_segments(tmp_path: Path) -> None:
+    a_csv = tmp_path / "segments_a.csv"
+    b_csv = tmp_path / "segments_b.csv"
+    _write_csv(
+        a_csv,
+        pd.DataFrame(
+            {
+                "sample_id": ["A"],
+                "segment_id": [1],
+                "n_est": [10],
+            }
+        ),
+    )
+    _write_csv(
+        b_csv,
+        pd.DataFrame(
+            {
+                "sample_id": ["A"],
+                "segment_id": [1],
+                "n_est": [12],
+            }
+        ),
+    )
+    diff = diff_core.diff_segments(a_csv, b_csv)
+    assert diff["changed"][("A", 1)]["n_est"]["b"] == 12.0
+
+
+def test_diff_mechanism(tmp_path: Path) -> None:
+    a_csv = tmp_path / "mechanism_a.csv"
+    b_csv = tmp_path / "mechanism_b.csv"
+    _write_csv(
+        a_csv,
+        pd.DataFrame(
+            {
+                "sample_id": ["S"],
+                "has_change": [False],
+                "tau": [10.0],
+            }
+        ),
+    )
+    _write_csv(
+        b_csv,
+        pd.DataFrame(
+            {
+                "sample_id": ["S"],
+                "has_change": [True],
+                "tau": [10.0],
+            }
+        ),
+    )
+    diff = diff_core.diff_mechanism(a_csv, b_csv)
+    assert diff["changed"][("S",)]["has_change"]["b"] is True
+
+
+def test_diff_ml(tmp_path: Path) -> None:
+    card_a = tmp_path / "model_a.json"
+    card_b = tmp_path / "model_b.json"
+    card_a.write_text(
+        json.dumps({"algorithm": "rf", "hyperparameters": {"max_depth": 3}}),
+        encoding="utf-8",
+    )
+    card_b.write_text(
+        json.dumps({"algorithm": "rf", "hyperparameters": {"max_depth": 4}}),
+        encoding="utf-8",
+    )
+    cv_a = tmp_path / "cv_a.json"
+    cv_b = tmp_path / "cv_b.json"
+    cv_a.write_text(json.dumps({"accuracy": 0.8}), encoding="utf-8")
+    cv_b.write_text(json.dumps({"accuracy": 0.9}), encoding="utf-8")
+
+    diff = diff_core.diff_ml(card_a, card_b, cv_a, cv_b)
+    assert diff["hyperparameters"]["max_depth"]["b"] == 4
+    assert diff["metrics"]["accuracy"]["delta"] == 0.09999999999999998
+
+
+def test_compose_diff_summary() -> None:
+    summary = diff_core.compose_diff_summary(
+        presets={"added": {"a": 1}},
+        msc={"metrics": {"mse": {"metric": "mse", "a": 1, "b": 0.5}}},
+        segments={"changed": {"foo": {}}},
+    )
+    assert summary["alerts"]
+    assert summary["kpis"][0]["metric"] == "mse"

--- a/ogum-ml-lite/tests/test_compare_loaders.py
+++ b/ogum-ml-lite/tests/test_compare_loaders.py
@@ -1,0 +1,51 @@
+"""Tests for the comparison loaders module."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+from ogum_lite.compare import loaders
+
+
+def test_find_run_root_directory(tmp_path: Path) -> None:
+    target = tmp_path / "run"
+    target.mkdir()
+    assert loaders.find_run_root(target) == target
+
+
+def test_find_run_root_zip(tmp_path: Path) -> None:
+    root = tmp_path / "artifact"
+    inner = root / "export"
+    inner.mkdir(parents=True)
+    (inner / "preset.yaml").write_text("foo: 1", encoding="utf-8")
+    archive = tmp_path / "artifact.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(inner / "preset.yaml", arcname="export/preset.yaml")
+    extracted = loaders.find_run_root(archive)
+    assert extracted.is_dir()
+    assert (extracted / "preset.yaml").exists()
+
+
+def test_scan_run_detects_artifacts(tmp_path: Path) -> None:
+    (tmp_path / "preset.yaml").write_text("foo: 1", encoding="utf-8")
+    (tmp_path / "msc.csv").write_text("mse_global\n1.0\n", encoding="utf-8")
+    manifest = loaders.scan_run(tmp_path)
+    assert manifest["presets"].name == "preset.yaml"
+    assert manifest["msc_csv"].name == "msc.csv"
+
+
+def test_loaders_helpers(tmp_path: Path) -> None:
+    json_path = tmp_path / "model_card.json"
+    json_path.write_text(json.dumps({"a": 1}), encoding="utf-8")
+    yaml_path = tmp_path / "preset.yaml"
+    yaml_path.write_text("foo: bar", encoding="utf-8")
+    csv_path = tmp_path / "table.csv"
+    pd.DataFrame({"x": [1, 2]}).to_csv(csv_path, index=False)
+
+    assert loaders.load_json(json_path) == {"a": 1}
+    assert loaders.load_yaml(yaml_path) == {"foo": "bar"}
+    csv = loaders.load_csv(csv_path)
+    assert list(csv.columns) == ["x"]

--- a/ogum-ml-lite/tests/test_compare_report.py
+++ b/ogum-ml-lite/tests/test_compare_report.py
@@ -1,0 +1,30 @@
+"""Report generation smoke tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from ogum_lite.compare import reporters
+
+
+def test_render_html_compare(tmp_path: Path) -> None:
+    html_path = reporters.render_html_compare(
+        tmp_path,
+        meta={"runs": ["a", "b"]},
+        diffs={
+            "summary": {"kpis": [{"metric": "mse", "a": 1, "b": 0.5}]},
+            "presets": {"changed": {"foo": {"a": 1, "b": 2}}},
+        },
+    )
+    assert html_path.exists()
+    content = html_path.read_text(encoding="utf-8")
+    assert "Ogum-ML" in content
+
+
+def test_export_xlsx_compare(tmp_path: Path) -> None:
+    out = tmp_path / "report.xlsx"
+    summary = pd.DataFrame([{"metric": "mse", "a": 1, "b": 0.5}])
+    tables = {"Presets": pd.DataFrame([{"key": "foo", "a": 1, "b": 2}])}
+    path = reporters.export_xlsx_compare(out, summary=summary, tables=tables)
+    assert path.exists()


### PR DESCRIPTION
## Summary
- add a compare package with loaders, semantic diffs and report exporters for Ogum-ML runs
- integrate the new compare commands into the CLI and document usage in the README
- ship a Streamlit "Compare Runs" page plus smoke tests covering the new comparison infrastructure

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68def5574eb08327ab6d3e2edb9ebca1