### PR TITLE
feat: publish runs to Zenodo and Figshare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Zenodo
+ZENODO_TOKEN=seu_token_aqui
+ZENODO_BASE=https://zenodo.org/api
+# ou sandbox:
+# ZENODO_BASE=https://sandbox.zenodo.org/api
+
+# Figshare
+FIGSHARE_TOKEN=seu_token_aqui
+FIGSHARE_BASE=https://api.figshare.com/v2

--- a/ogum-ml-lite/ogum_lite/publish/__init__.py
+++ b/ogum-ml-lite/ogum_lite/publish/__init__.py
@@ -1,0 +1,31 @@
+"""Utilities for preparing and publishing Ogum-ML results."""
+
+from .metadata import (
+    PublicationAuthor,
+    PublicationMeta,
+    from_yaml,
+    to_yaml,
+    validate_meta,
+)
+from .packer import gather_run_artifacts, make_publish_bundle, pack_zip
+from .workflow import (
+    prepare_run_for_publish,
+    publish_status,
+    publish_to_figshare,
+    publish_to_zenodo,
+)
+
+__all__ = [
+    "PublicationAuthor",
+    "PublicationMeta",
+    "from_yaml",
+    "to_yaml",
+    "validate_meta",
+    "gather_run_artifacts",
+    "pack_zip",
+    "make_publish_bundle",
+    "prepare_run_for_publish",
+    "publish_to_zenodo",
+    "publish_to_figshare",
+    "publish_status",
+]

--- a/ogum-ml-lite/ogum_lite/publish/figshare_client.py
+++ b/ogum-ml-lite/ogum_lite/publish/figshare_client.py
@@ -1,0 +1,81 @@
+"""Minimal Figshare API client for publication workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from .metadata import PublicationMeta
+
+
+class FigshareClient:
+    """Client wrapper for Figshare article management endpoints."""
+
+    def __init__(self, token: str, base_url: str) -> None:
+        if not token:
+            msg = (
+                "Figshare token is required. "
+                "Configure FIGSHARE_TOKEN in the environment."
+            )
+            raise ValueError(msg)
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"token {token}"})
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+        url = f"{self.base_url}{endpoint}"
+        response = self.session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def create_article(self, meta: PublicationMeta) -> dict[str, Any]:
+        """Create a Figshare article using the supplied metadata."""
+
+        payload = self._serialize_metadata(meta)
+        response = self._request("POST", "/account/articles", json=payload)
+        return response.json()
+
+    def initiate_upload(self, article_id: int, path: Path) -> dict[str, Any]:
+        """Upload a file to the specified article."""
+
+        with path.open("rb") as handle:
+            files = {"filedata": (path.name, handle)}
+            response = self._request(
+                "POST", f"/account/articles/{article_id}/files", files=files
+            )
+        return response.json()
+
+    def publish(self, article_id: int) -> dict[str, Any]:
+        """Publish an article and expose it publicly."""
+
+        response = self._request("POST", f"/account/articles/{article_id}/publish")
+        return response.json()
+
+    def get_article(self, article_id: int) -> dict[str, Any]:
+        """Fetch article metadata from Figshare."""
+
+        response = self._request("GET", f"/account/articles/{article_id}")
+        return response.json()
+
+    def _serialize_metadata(self, meta: PublicationMeta) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "title": meta.title,
+            "description": meta.description,
+            "version": meta.version,
+            "authors": [author.name for author in meta.authors],
+            "keywords": meta.keywords,
+            "license": meta.license,
+        }
+        if meta.category:
+            payload["defined_type"] = meta.category
+        if meta.funding:
+            payload["funding"] = list(meta.funding)
+        if meta.related_identifiers:
+            payload["references"] = [
+                item.get("identifier")
+                for item in meta.related_identifiers
+                if item.get("identifier")
+            ]
+        return payload

--- a/ogum-ml-lite/ogum_lite/publish/metadata.py
+++ b/ogum-ml-lite/ogum_lite/publish/metadata.py
@@ -1,0 +1,251 @@
+"""Metadata models and utilities for scientific publication workflows."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+@dataclass(slots=True)
+class PublicationAuthor:
+    """Author information for a publication record.
+
+    Parameters
+    ----------
+    name
+        Full name of the author as it should appear in the record.
+    affiliation
+        Affiliation of the author (laboratory, institution or company). Optional.
+    orcid
+        ORCID identifier for the author, if available.
+    """
+
+    name: str
+    affiliation: str | None = None
+    orcid: str | None = None
+
+
+@dataclass(slots=True)
+class PublicationMeta:
+    """Canonical metadata describing a publication package.
+
+    Parameters
+    ----------
+    title
+        Title of the deposition or article.
+    description
+        Rich description of the content. Markdown or HTML is accepted by most
+        repositories.
+    version
+        Semantic version or label identifying the release.
+    authors
+        List of authors contributing to the deposition.
+    keywords
+        Keywords that summarise the content.
+    license
+        Short license identifier (e.g. ``"CC-BY-4.0"`` or ``"MIT"``).
+    funding
+        Optional list describing funding acknowledgements.
+    related_identifiers
+        Optional list of mappings describing related works. Each mapping should
+        at least contain ``identifier`` and ``relation`` keys.
+    upload_files
+        Optional list of extra files to upload besides the generated bundle.
+    community
+        Optional Zenodo community slug.
+    category
+        Optional Figshare article category.
+    """
+
+    title: str
+    description: str
+    version: str
+    authors: list[PublicationAuthor] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    license: str = ""
+    funding: list[str] | None = None
+    related_identifiers: list[dict[str, Any]] | None = None
+    upload_files: list[Path] | None = None
+    community: str | None = None
+    category: str | None = None
+
+
+def _require(condition: bool, issues: list[str], message: str) -> None:
+    if not condition:
+        issues.append(message)
+
+
+def _is_non_empty_str(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _validate_authors(authors: Iterable[PublicationAuthor], issues: list[str]) -> None:
+    authors_list = list(authors)
+    _require(bool(authors_list), issues, "At least one author is required.")
+    for index, author in enumerate(authors_list):
+        if not _is_non_empty_str(author.name):
+            issues.append(f"Author #{index + 1} name must be a non-empty string.")
+        if author.orcid and not _validate_orcid(author.orcid):
+            msg = (
+                f"Author #{index + 1} ORCID '{author.orcid}' is not valid "
+                "(format: 0000-0000-0000-0000)."
+            )
+            issues.append(msg)
+
+
+def _validate_orcid(orcid: str) -> bool:
+    if not isinstance(orcid, str):
+        return False
+    parts = orcid.split("-")
+    if len(parts) != 4:
+        return False
+    if any(len(part) != 4 or not part.isdigit() for part in parts[:-1]):
+        return False
+    last_part = parts[-1]
+    return len(last_part) == 4 and all(
+        ch.isdigit() or ch.upper() == "X" for ch in last_part
+    )
+
+
+def _validate_keywords(keywords: Iterable[str], issues: list[str]) -> None:
+    provided = list(keywords)
+    kw_list = [kw for kw in provided if _is_non_empty_str(kw)]
+    _require(bool(kw_list), issues, "At least one keyword is required.")
+    if len(kw_list) != len(provided):
+        issues.append("Keywords must be non-empty strings.")
+
+
+def _validate_related_identifiers(
+    related_identifiers: Iterable[dict[str, Any]] | None, issues: list[str]
+) -> None:
+    if related_identifiers is None:
+        return
+    for index, entry in enumerate(related_identifiers):
+        if not isinstance(entry, dict):
+            issues.append(
+                "Related identifiers must be dictionaries with identifier metadata."
+            )
+            continue
+        if not _is_non_empty_str(entry.get("identifier")):
+            msg = (
+                f"Related identifier #{index + 1} must include a non-empty "
+                "'identifier'."
+            )
+            issues.append(msg)
+        if not _is_non_empty_str(entry.get("relation")):
+            issues.append(
+                f"Related identifier #{index + 1} must include a non-empty 'relation'."
+            )
+
+
+def _validate_upload_files(
+    upload_files: Iterable[Path] | None, issues: list[str]
+) -> None:
+    if upload_files is None:
+        return
+    for path in upload_files:
+        if not isinstance(path, Path):
+            issues.append("Upload files must be provided as pathlib.Path objects.")
+
+
+def validate_meta(meta: PublicationMeta) -> dict[str, Any]:
+    """Validate metadata values for completeness.
+
+    Parameters
+    ----------
+    meta
+        Metadata instance to validate.
+
+    Returns
+    -------
+    dict
+        Mapping containing ``ok`` boolean flag and a list of textual issues.
+    """
+
+    issues: list[str] = []
+    _require(_is_non_empty_str(meta.title), issues, "Title is required.")
+    _require(_is_non_empty_str(meta.description), issues, "Description is required.")
+    _require(_is_non_empty_str(meta.version), issues, "Version is required.")
+    _validate_authors(meta.authors, issues)
+    _validate_keywords(meta.keywords, issues)
+    _require(_is_non_empty_str(meta.license), issues, "License is required.")
+    _validate_related_identifiers(meta.related_identifiers, issues)
+    _validate_upload_files(meta.upload_files, issues)
+    return {"ok": not issues, "issues": issues}
+
+
+def from_yaml(path: Path) -> PublicationMeta:
+    """Load publication metadata from a YAML file.
+
+    Parameters
+    ----------
+    path
+        Path to a YAML document describing :class:`PublicationMeta` fields.
+
+    Returns
+    -------
+    PublicationMeta
+        Metadata object populated with the file contents.
+    """
+
+    with path.open("r", encoding="utf-8") as handle:
+        raw_data = yaml.safe_load(handle) or {}
+    authors = [
+        PublicationAuthor(**author_dict) for author_dict in raw_data.get("authors", [])
+    ]
+    upload_files = raw_data.get("upload_files")
+    if upload_files is not None:
+        resolved_files: list[Path] = []
+        for item in upload_files:
+            path_obj = Path(item)
+            if not path_obj.is_absolute():
+                path_obj = (path.parent / path_obj).resolve()
+            resolved_files.append(path_obj)
+        upload_files = resolved_files
+    return PublicationMeta(
+        title=raw_data.get("title", ""),
+        description=raw_data.get("description", ""),
+        version=raw_data.get("version", ""),
+        authors=authors,
+        keywords=list(raw_data.get("keywords", [])),
+        license=raw_data.get("license", ""),
+        funding=(
+            list(raw_data.get("funding", []))
+            if raw_data.get("funding") is not None
+            else None
+        ),
+        related_identifiers=(
+            list(raw_data.get("related_identifiers", []))
+            if raw_data.get("related_identifiers") is not None
+            else None
+        ),
+        upload_files=upload_files,
+        community=raw_data.get("community"),
+        category=raw_data.get("category"),
+    )
+
+
+def _serialize_author(author: PublicationAuthor) -> dict[str, Any]:
+    return {key: value for key, value in asdict(author).items() if value is not None}
+
+
+def to_yaml(meta: PublicationMeta, path: Path) -> None:
+    """Write metadata information to a YAML file.
+
+    Parameters
+    ----------
+    meta
+        Metadata instance to serialise.
+    path
+        Output YAML file path.
+    """
+
+    serialisable = asdict(meta)
+    serialisable["authors"] = [_serialize_author(author) for author in meta.authors]
+    if meta.upload_files is not None:
+        serialisable["upload_files"] = [str(item) for item in meta.upload_files]
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(serialisable, handle, sort_keys=False, allow_unicode=True)

--- a/ogum-ml-lite/ogum_lite/publish/packer.py
+++ b/ogum-ml-lite/ogum_lite/publish/packer.py
@@ -1,0 +1,131 @@
+"""Artifact gathering and packaging helpers for publication bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path
+
+_ARTIFACT_CANDIDATES: Mapping[str, tuple[str, ...]] = {
+    "report.html": ("report.html",),
+    "report.xlsx": ("report.xlsx",),
+    "msc.csv": ("msc.csv",),
+    "msc.png": ("msc.png",),
+    "segments.json": ("segments.json",),
+    "n_segments.csv": ("n_segments.csv",),
+    "mech_report.csv": ("mech_report.csv",),
+    "model_card.json": ("model_card.json",),
+    "cv_metrics.json": ("cv_metrics.json",),
+    "theta.zip": ("theta.zip", "theta_curves.zip", "theta_csv.zip"),
+    "features.csv": ("features.csv",),
+    "presets.yaml": ("presets.yaml",),
+    "run_log.jsonl": ("run_log.jsonl",),
+    "telemetry.jsonl": ("telemetry.jsonl",),
+}
+
+
+def _first_existing(base: Path, candidates: tuple[str, ...]) -> Path | None:
+    for candidate in candidates:
+        path = base / candidate
+        if path.exists():
+            return path
+    return None
+
+
+def gather_run_artifacts(run_dir: Path) -> dict[str, Path]:
+    """Collect known artifact files from a run directory.
+
+    Parameters
+    ----------
+    run_dir
+        Path containing generated run artifacts.
+
+    Returns
+    -------
+    dict
+        Mapping of artifact file names to their paths.
+    """
+
+    if not run_dir.exists():
+        msg = f"Run directory '{run_dir}' does not exist."
+        raise FileNotFoundError(msg)
+
+    artifacts: dict[str, Path] = {}
+    for arcname, candidates in _ARTIFACT_CANDIDATES.items():
+        path = _first_existing(run_dir, candidates)
+        if path:
+            artifacts[path.name] = path
+    return artifacts
+
+
+def pack_zip(artifacts: dict[str, Path], out_zip: Path) -> Path:
+    """Create a deterministic ZIP archive of collected artifacts.
+
+    Parameters
+    ----------
+    artifacts
+        Mapping of archive names to source paths.
+    out_zip
+        Destination path for the generated archive.
+
+    Returns
+    -------
+    Path
+        Path to the generated ZIP archive.
+    """
+
+    out_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_zip, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for arcname in sorted(artifacts):
+            source = artifacts[arcname]
+            info = zipfile.ZipInfo(arcname)
+            info.date_time = (1980, 1, 1, 0, 0, 0)
+            info.external_attr = 0o644 << 16
+            with source.open("rb") as handle:
+                data = handle.read()
+            bundle.writestr(info, data)
+    digest = hashlib.sha256(out_zip.read_bytes()).hexdigest()
+    checksum_path = out_zip.with_suffix(out_zip.suffix + ".sha256")
+    with checksum_path.open("w", encoding="utf-8") as handle:
+        handle.write(f"{digest}  {out_zip.name}\n")
+    return out_zip
+
+
+def make_publish_bundle(
+    run_dir: Path, extra_files: list[Path] | None, out_dir: Path
+) -> dict[str, object]:
+    """Build the publish bundle for a run directory.
+
+    Parameters
+    ----------
+    run_dir
+        Directory containing the run artefacts.
+    extra_files
+        Optional additional files to be uploaded alongside the bundle.
+    out_dir
+        Output directory for generated files.
+
+    Returns
+    -------
+    dict
+        A dictionary containing paths to the zip archive, checksum file and the
+        manifest data.
+    """
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = gather_run_artifacts(run_dir)
+    zip_path = out_dir / "bundle.zip"
+    pack_zip(artifacts, zip_path)
+    checksum_path = zip_path.with_suffix(zip_path.suffix + ".sha256")
+    manifest: dict[str, object] = {
+        "run_dir": str(run_dir),
+        "artifacts": {name: str(path) for name, path in artifacts.items()},
+    }
+    if extra_files:
+        manifest["extra_files"] = [
+            str(path.relative_to(out_dir)) for path in extra_files
+        ]
+    manifest["zip"] = str(zip_path.relative_to(out_dir))
+    manifest["checksum"] = checksum_path.read_text(encoding="utf-8").strip()
+    return {"zip": zip_path, "checksum": checksum_path, "manifest": manifest}

--- a/ogum-ml-lite/ogum_lite/publish/workflow.py
+++ b/ogum-ml-lite/ogum_lite/publish/workflow.py
@@ -1,0 +1,212 @@
+"""High-level workflows orchestrating publication preparation and uploads."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Mapping
+
+from .figshare_client import FigshareClient
+from .metadata import PublicationMeta, from_yaml, to_yaml, validate_meta
+from .packer import make_publish_bundle
+from .zenodo_client import ZenodoClient
+
+
+def _metadata_to_dict(meta: PublicationMeta) -> dict:
+    authors = []
+    for author in meta.authors:
+        authors.append(
+            {
+                "name": author.name,
+                "affiliation": author.affiliation,
+                "orcid": author.orcid,
+            }
+        )
+    return {
+        "title": meta.title,
+        "description": meta.description,
+        "version": meta.version,
+        "authors": authors,
+        "keywords": list(meta.keywords),
+        "license": meta.license,
+        "funding": list(meta.funding) if meta.funding is not None else None,
+        "related_identifiers": (
+            list(meta.related_identifiers)
+            if meta.related_identifiers is not None
+            else None
+        ),
+        "upload_files": (
+            [str(path) for path in meta.upload_files]
+            if meta.upload_files is not None
+            else None
+        ),
+        "community": meta.community,
+        "category": meta.category,
+    }
+
+
+def prepare_run_for_publish(run_dir: Path, meta_yaml: Path, out_dir: Path) -> dict:
+    """Prepare a run directory for publication.
+
+    The function validates metadata, copies auxiliary files and creates the
+    publish bundle.
+    """
+
+    meta = from_yaml(meta_yaml)
+    validation = validate_meta(meta)
+    if not validation["ok"]:
+        issues = "; ".join(validation["issues"])
+        msg = f"Invalid publication metadata: {issues}"
+        raise ValueError(msg)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    metadata_copy = out_dir / "metadata.yaml"
+    to_yaml(meta, metadata_copy)
+
+    extra_files: list[Path] = []
+    if meta.upload_files:
+        extras_dir = out_dir / "extra_files"
+        extras_dir.mkdir(parents=True, exist_ok=True)
+        for path in meta.upload_files:
+            if not path.exists():
+                msg = f"Upload file '{path}' does not exist."
+                raise FileNotFoundError(msg)
+            destination = extras_dir / path.name
+            shutil.copy2(path, destination)
+            extra_files.append(destination)
+
+    bundle = make_publish_bundle(run_dir, extra_files, out_dir)
+
+    manifest_data = bundle["manifest"].copy()
+    manifest_data["metadata"] = _metadata_to_dict(meta)
+    manifest_data["metadata_path"] = str(metadata_copy)
+    manifest_path = out_dir / "publish_manifest.json"
+    manifest_path.write_text(json.dumps(manifest_data, indent=2), encoding="utf-8")
+
+    return {
+        "manifest_path": manifest_path,
+        "metadata_path": metadata_copy,
+        "bundle_zip": bundle["zip"],
+        "checksum_path": bundle["checksum"],
+    }
+
+
+def _load_manifest(bundle_dir: Path) -> dict:
+    manifest_path = bundle_dir / "publish_manifest.json"
+    if not manifest_path.exists():
+        msg = f"Bundle manifest not found at {manifest_path}."
+        raise FileNotFoundError(msg)
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def _load_metadata(bundle_dir: Path) -> PublicationMeta:
+    metadata_path = bundle_dir / "metadata.yaml"
+    if not metadata_path.exists():
+        msg = f"Metadata YAML not found at {metadata_path}."
+        raise FileNotFoundError(msg)
+    return from_yaml(metadata_path)
+
+
+def _resolve_path(bundle_dir: Path, path_str: str) -> Path:
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = bundle_dir / path
+    return path
+
+
+def publish_to_zenodo(bundle_dir: Path, env: Mapping[str, str]) -> dict:
+    """Publish a previously prepared bundle to Zenodo."""
+
+    manifest = _load_manifest(bundle_dir)
+    meta = _load_metadata(bundle_dir)
+    token = env.get("ZENODO_TOKEN", "")
+    if not token:
+        msg = "ZENODO_TOKEN is not configured."
+        raise RuntimeError(msg)
+    base_url = env.get("ZENODO_BASE", "https://zenodo.org/api")
+
+    client = ZenodoClient(token=token, base_url=base_url)
+    deposition = client.create_deposition(meta)
+    deposition_id = deposition.get("id")
+    if deposition_id is None:
+        msg = "Zenodo deposition response missing 'id'."
+        raise RuntimeError(msg)
+
+    bundle_path = _resolve_path(bundle_dir, manifest["zip"])
+    client.upload_file(int(deposition_id), bundle_path)
+
+    for extra in manifest.get("extra_files", []):
+        client.upload_file(int(deposition_id), _resolve_path(bundle_dir, extra))
+
+    publish_response = client.publish(int(deposition_id))
+    record = client.get_record(int(deposition_id))
+    receipt = {
+        "platform": "zenodo",
+        "deposition_id": deposition_id,
+        "doi": record.get("doi") or record.get("metadata", {}).get("doi"),
+        "conceptdoi": record.get("conceptdoi")
+        or record.get("metadata", {}).get("conceptdoi"),
+        "url": record.get("links", {}).get("html"),
+        "publish_response": publish_response,
+    }
+
+    receipt_path = bundle_dir / "zenodo_receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    return receipt
+
+
+def publish_to_figshare(bundle_dir: Path, env: Mapping[str, str]) -> dict:
+    """Publish a previously prepared bundle to Figshare."""
+
+    manifest = _load_manifest(bundle_dir)
+    meta = _load_metadata(bundle_dir)
+    token = env.get("FIGSHARE_TOKEN", "")
+    if not token:
+        msg = "FIGSHARE_TOKEN is not configured."
+        raise RuntimeError(msg)
+    base_url = env.get("FIGSHARE_BASE", "https://api.figshare.com/v2")
+
+    client = FigshareClient(token=token, base_url=base_url)
+    article = client.create_article(meta)
+    article_id = article.get("id") or article.get("article_id")
+    if article_id is None:
+        msg = "Figshare response missing article identifier."
+        raise RuntimeError(msg)
+
+    bundle_path = _resolve_path(bundle_dir, manifest["zip"])
+    client.initiate_upload(int(article_id), bundle_path)
+    for extra in manifest.get("extra_files", []):
+        client.initiate_upload(int(article_id), _resolve_path(bundle_dir, extra))
+
+    publish_response = client.publish(int(article_id))
+    record = client.get_article(int(article_id))
+    receipt = {
+        "platform": "figshare",
+        "article_id": article_id,
+        "doi": record.get("doi") or record.get("doi_url"),
+        "url": record.get("url_public_html") or record.get("url"),
+        "publish_response": publish_response,
+    }
+
+    receipt_path = bundle_dir / "figshare_receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    return receipt
+
+
+def publish_status(bundle_dir: Path) -> dict:
+    """Summarise publication receipts for the given bundle directory."""
+
+    status: dict[str, dict] = {}
+    manifest = _load_manifest(bundle_dir)
+    status["manifest"] = manifest
+
+    zenodo_receipt = bundle_dir / "zenodo_receipt.json"
+    if zenodo_receipt.exists():
+        status["zenodo"] = json.loads(zenodo_receipt.read_text(encoding="utf-8"))
+
+    figshare_receipt = bundle_dir / "figshare_receipt.json"
+    if figshare_receipt.exists():
+        status["figshare"] = json.loads(figshare_receipt.read_text(encoding="utf-8"))
+
+    return status

--- a/ogum-ml-lite/ogum_lite/publish/zenodo_client.py
+++ b/ogum-ml-lite/ogum_lite/publish/zenodo_client.py
@@ -1,0 +1,98 @@
+"""Minimal REST client for interacting with the Zenodo deposition API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from .metadata import PublicationMeta
+
+
+class ZenodoClient:
+    """Client providing a thin wrapper around the Zenodo deposition API."""
+
+    def __init__(self, token: str, base_url: str) -> None:
+        if not token:
+            msg = "Zenodo token is required. Configure ZENODO_TOKEN in the environment."
+            raise ValueError(msg)
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+        url = f"{self.base_url}{endpoint}"
+        response = self.session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def create_deposition(self, meta: PublicationMeta) -> dict[str, Any]:
+        """Create a new Zenodo deposition for the provided metadata.
+
+        Parameters
+        ----------
+        meta
+            Publication metadata.
+
+        Returns
+        -------
+        dict
+            JSON response describing the deposition, including the identifier.
+        """
+
+        payload = {"metadata": self._serialize_metadata(meta)}
+        response = self._request("POST", "/deposit/depositions", json=payload)
+        return response.json()
+
+    def upload_file(self, deposition_id: int, path: Path) -> dict[str, Any]:
+        """Upload a file to an existing deposition."""
+
+        with path.open("rb") as handle:
+            files = {"file": (path.name, handle)}
+            response = self._request(
+                "POST", f"/deposit/depositions/{deposition_id}/files", files=files
+            )
+        return response.json()
+
+    def publish(self, deposition_id: int) -> dict[str, Any]:
+        """Publish a deposition, minting the DOI."""
+
+        response = self._request(
+            "POST", f"/deposit/depositions/{deposition_id}/actions/publish"
+        )
+        return response.json()
+
+    def get_record(self, deposition_id: int) -> dict[str, Any]:
+        """Retrieve the deposition record."""
+
+        response = self._request("GET", f"/deposit/depositions/{deposition_id}")
+        return response.json()
+
+    def _serialize_metadata(self, meta: PublicationMeta) -> dict[str, Any]:
+        creators = []
+        for author in meta.authors:
+            creator = {"name": author.name}
+            if author.affiliation:
+                creator["affiliation"] = author.affiliation
+            if author.orcid:
+                creator["orcid"] = author.orcid
+            creators.append(creator)
+        metadata: dict[str, Any] = {
+            "title": meta.title,
+            "upload_type": "dataset",
+            "description": meta.description,
+            "version": meta.version,
+            "creators": creators,
+            "keywords": meta.keywords,
+            "license": meta.license,
+        }
+        if meta.funding:
+            metadata["funding"] = list(meta.funding)
+        if meta.related_identifiers:
+            metadata["related_identifiers"] = [
+                dict(item) for item in meta.related_identifiers
+            ]
+        if meta.community:
+            metadata["communities"] = [{"identifier": meta.community}]
+        return metadata

--- a/ogum-ml-lite/tests/test_publish_figshare.py
+++ b/ogum-ml-lite/tests/test_publish_figshare.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ogum_lite.publish import metadata
+from ogum_lite.publish.workflow import prepare_run_for_publish, publish_to_figshare
+
+
+class FakeFigshareClient:
+    def __init__(self, token: str, base_url: str) -> None:
+        self.token = token
+        self.base_url = base_url
+        self.uploaded: list[Path] = []
+
+    def create_article(self, meta: metadata.PublicationMeta) -> dict[str, Any]:
+        return {"id": 77}
+
+    def initiate_upload(self, article_id: int, path: Path) -> dict[str, Any]:
+        self.uploaded.append(path)
+        return {"id": article_id, "name": path.name}
+
+    def publish(self, article_id: int) -> dict[str, Any]:
+        return {"status": "ok", "id": article_id}
+
+    def get_article(self, article_id: int) -> dict[str, Any]:
+        return {
+            "doi": "10.6084/m9.figshare.777",
+            "url_public_html": "https://figshare.com/articles/777",
+        }
+
+
+@pytest.fixture()
+def sample_bundle(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "report.html").write_text("report", encoding="utf-8")
+    (run_dir / "model_card.json").write_text("{}", encoding="utf-8")
+
+    meta_yaml = tmp_path / "meta.yaml"
+    meta = metadata.PublicationMeta(
+        title="Ogum Figshare",
+        description="Bundle for figshare tests.",
+        version="v0.1.1",
+        authors=[metadata.PublicationAuthor(name="Alice")],
+        keywords=["ogum"],
+        license="MIT",
+    )
+    metadata.to_yaml(meta, meta_yaml)
+
+    bundle_dir = tmp_path / "bundle"
+    prepare_run_for_publish(run_dir, meta_yaml, bundle_dir)
+    return bundle_dir
+
+
+def test_publish_to_figshare_with_receipt(
+    monkeypatch: pytest.MonkeyPatch, sample_bundle: Path
+) -> None:
+    created_clients: list[FakeFigshareClient] = []
+
+    def _factory(token: str, base_url: str) -> FakeFigshareClient:
+        client = FakeFigshareClient(token, base_url)
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr("ogum_lite.publish.workflow.FigshareClient", _factory)
+
+    receipt = publish_to_figshare(
+        sample_bundle,
+        env={
+            "FIGSHARE_TOKEN": "secret",
+            "FIGSHARE_BASE": "https://api.figshare.com/v2",
+        },
+    )
+
+    assert receipt["doi"] == "10.6084/m9.figshare.777"
+    assert receipt["url"] == "https://figshare.com/articles/777"
+
+    receipt_path = sample_bundle / "figshare_receipt.json"
+    saved = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert saved["doi"] == "10.6084/m9.figshare.777"
+
+    assert created_clients
+    assert created_clients[0].uploaded
+    assert created_clients[0].uploaded[0].name == "bundle.zip"
+
+
+def test_publish_to_figshare_requires_token(sample_bundle: Path) -> None:
+    with pytest.raises(RuntimeError):
+        publish_to_figshare(sample_bundle, env={})

--- a/ogum-ml-lite/tests/test_publish_metadata.py
+++ b/ogum-ml-lite/tests/test_publish_metadata.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ogum_lite.publish.metadata import (
+    PublicationAuthor,
+    PublicationMeta,
+    from_yaml,
+    to_yaml,
+    validate_meta,
+)
+
+
+def test_validate_meta_success() -> None:
+    meta = PublicationMeta(
+        title="Ogum ML Results",
+        description="Comprehensive run outputs.",
+        version="v0.3.0",
+        authors=[PublicationAuthor(name="Alice Doe", affiliation="Ogum Lab")],
+        keywords=["sintering", "ogum"],
+        license="MIT",
+        funding=["CNPq-123"],
+        related_identifiers=[
+            {"identifier": "10.5281/zenodo.123", "relation": "isSupplementTo"}
+        ],
+    )
+    result = validate_meta(meta)
+    assert result["ok"] is True
+    assert result["issues"] == []
+
+
+def test_validate_meta_reports_missing_fields() -> None:
+    meta = PublicationMeta(title="", description="", version="", license="")
+    validation = validate_meta(meta)
+    assert validation["ok"] is False
+    assert "Title is required." in validation["issues"]
+    assert "Description is required." in validation["issues"]
+    assert "Version is required." in validation["issues"]
+    assert "At least one author is required." in validation["issues"]
+    assert "At least one keyword is required." in validation["issues"]
+    assert "License is required." in validation["issues"]
+
+
+def test_metadata_yaml_roundtrip(tmp_path: Path) -> None:
+    extra_file = tmp_path / "notes.txt"
+    extra_file.write_text("important notes", encoding="utf-8")
+
+    meta = PublicationMeta(
+        title="Ogum Run",
+        description="Important scientific artefacts.",
+        version="v1.0.0",
+        authors=[
+            PublicationAuthor(name="Alice Doe"),
+            PublicationAuthor(name="Bob Ray"),
+        ],
+        keywords=["ogum", "ml"],
+        license="CC-BY-4.0",
+        upload_files=[extra_file],
+    )
+
+    yaml_path = tmp_path / "meta.yaml"
+    to_yaml(meta, yaml_path)
+
+    loaded = from_yaml(yaml_path)
+    assert loaded.title == meta.title
+    assert loaded.description == meta.description
+    assert loaded.version == meta.version
+    assert [author.name for author in loaded.authors] == [
+        "Alice Doe",
+        "Bob Ray",
+    ]
+    assert loaded.upload_files == [extra_file.resolve()]
+
+    validation = validate_meta(loaded)
+    assert validation["ok"] is True

--- a/ogum-ml-lite/tests/test_publish_packer.py
+++ b/ogum-ml-lite/tests/test_publish_packer.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+from ogum_lite.publish.packer import gather_run_artifacts, make_publish_bundle
+
+
+def _create_file(path: Path, content: str = "data") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_gather_and_bundle_run(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _create_file(run_dir / "report.html")
+    _create_file(run_dir / "model_card.json", "{}")
+    _create_file(run_dir / "cv_metrics.json", "{}")
+
+    artifacts = gather_run_artifacts(run_dir)
+    assert "report.html" in artifacts
+    assert "model_card.json" in artifacts
+    assert artifacts["report.html"].name == "report.html"
+
+    out_dir = tmp_path / "bundle"
+    extra_dir = out_dir / "extra_files"
+    _create_file(extra_dir / "readme.txt", "info")
+
+    bundle = make_publish_bundle(run_dir, [extra_dir / "readme.txt"], out_dir)
+    zip_path = bundle["zip"]
+    checksum_path = bundle["checksum"]
+    manifest = bundle["manifest"]
+
+    assert zip_path.exists()
+    assert checksum_path.exists()
+    assert manifest["zip"] == "bundle.zip"
+    assert manifest["extra_files"] == ["extra_files/readme.txt"]
+    assert set(manifest["artifacts"]) == {
+        "report.html",
+        "model_card.json",
+        "cv_metrics.json",
+    }
+
+    with zipfile.ZipFile(zip_path) as archive:
+        assert set(archive.namelist()) == {
+            "cv_metrics.json",
+            "model_card.json",
+            "report.html",
+        }
+
+    digest = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    recorded_digest = checksum_path.read_text(encoding="utf-8").split()[0]
+    assert digest == recorded_digest

--- a/ogum-ml-lite/tests/test_publish_zenodo.py
+++ b/ogum-ml-lite/tests/test_publish_zenodo.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ogum_lite.publish import metadata
+from ogum_lite.publish.workflow import prepare_run_for_publish, publish_to_zenodo
+
+
+class FakeZenodoClient:
+    def __init__(self, token: str, base_url: str) -> None:
+        self.token = token
+        self.base_url = base_url
+        self.uploaded: list[Path] = []
+        self.received_meta: metadata.PublicationMeta | None = None
+
+    def create_deposition(self, meta: metadata.PublicationMeta) -> dict[str, Any]:
+        self.received_meta = meta
+        return {"id": 42}
+
+    def upload_file(self, deposition_id: int, path: Path) -> dict[str, Any]:
+        self.uploaded.append(path)
+        return {"filename": path.name, "id": deposition_id}
+
+    def publish(self, deposition_id: int) -> dict[str, Any]:
+        return {"status": "published", "id": deposition_id}
+
+    def get_record(self, deposition_id: int) -> dict[str, Any]:
+        return {
+            "doi": "10.5281/zenodo.9999",
+            "links": {"html": "https://zenodo.org/record/9999"},
+        }
+
+
+@pytest.fixture()
+def sample_run(tmp_path: Path) -> tuple[Path, Path]:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "report.html").write_text("report", encoding="utf-8")
+    (run_dir / "model_card.json").write_text("{}", encoding="utf-8")
+
+    meta_yaml = tmp_path / "meta.yaml"
+    meta = metadata.PublicationMeta(
+        title="Ogum Run",
+        description="Results ready for sharing.",
+        version="v0.1.0",
+        authors=[metadata.PublicationAuthor(name="Alice")],
+        keywords=["ogum"],
+        license="MIT",
+    )
+    metadata.to_yaml(meta, meta_yaml)
+    return run_dir, meta_yaml
+
+
+def test_publish_to_zenodo_creates_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sample_run: tuple[Path, Path],
+) -> None:
+    run_dir, meta_yaml = sample_run
+    bundle_dir = tmp_path / "bundle"
+    prepare_run_for_publish(run_dir, meta_yaml, bundle_dir)
+
+    created_clients: list[FakeZenodoClient] = []
+
+    def _factory(token: str, base_url: str) -> FakeZenodoClient:
+        client = FakeZenodoClient(token, base_url)
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr("ogum_lite.publish.workflow.ZenodoClient", _factory)
+
+    receipt = publish_to_zenodo(
+        bundle_dir,
+        env={"ZENODO_TOKEN": "token", "ZENODO_BASE": "https://sandbox.zenodo.org/api"},
+    )
+
+    assert receipt["doi"] == "10.5281/zenodo.9999"
+    assert receipt["url"] == "https://zenodo.org/record/9999"
+
+    receipt_path = bundle_dir / "zenodo_receipt.json"
+    assert receipt_path.exists()
+    saved = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert saved["doi"] == "10.5281/zenodo.9999"
+
+    assert created_clients
+    client = created_clients[0]
+    assert client.received_meta is not None
+    assert client.uploaded
+    assert client.uploaded[0].name == "bundle.zip"
+
+
+def test_publish_to_zenodo_requires_token(
+    tmp_path: Path, sample_run: tuple[Path, Path]
+) -> None:
+    run_dir, meta_yaml = sample_run
+    bundle_dir = tmp_path / "bundle"
+    prepare_run_for_publish(run_dir, meta_yaml, bundle_dir)
+
+    with pytest.raises(RuntimeError):
+        publish_to_zenodo(bundle_dir, env={})


### PR DESCRIPTION
## Summary
- add publication metadata schema, bundle packer, and REST clients for Zenodo and Figshare
- extend the CLI with publish commands that prepare bundles, upload them, and persist receipts
- document the publication workflow, provide environment examples, and cover the new flows with unit tests

## Testing
- black --check .
- ruff check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68defe8eb274832797e72e5ce381cfc1