### PR TITLE
Add educational training mode with guided UI and exports

### DIFF
--- a/ogum-ml-lite/README.md
+++ b/ogum-ml-lite/README.md
@@ -101,6 +101,14 @@ streamlit run app/streamlit_app.py
 - **Estado**: `app/services/state.py` centraliza `session_state`, workspace e
   registro de artefatos; telemetria opcional (`OGUML_TELEMETRY=0` desliga).
 
+## Fase 17 — Modo Educacional
+
+- **Como ativar**: escolha "Modo Educacional" no menu lateral do Streamlit. O fluxo traz três passos (Carregar Dados → MSC & n → Explorar/Exportar).
+- **Conteúdo incluso**: cards conceituais bilingues (pt/en), simulações interativas de θ(Ea), colapso MSC e linearização de Blaine, além de exercícios com checagem automática.
+- **Export educacional**: gere um HTML estático sempre disponível; se instalar `pip install "ogum-ml[pdf]"`, o botão de PDF usa ReportLab para montar o resumo com gráficos.
+- **Limitações**: focado em treinamento. Usa dataset exemplo se nenhum CSV for enviado e não substitui as abas avançadas para análises completas.
+- **Novos exercícios**: implemente funções em `app/edu/exercises.py` retornando `Exercise(key, statement_md, inputs_spec, evaluate)`. O método `evaluate` deve receber um `Mapping[str, float]` e retornar `{"score": float, "feedback": str}`.
+
 ### Modo guiado (Wizard)
 
 - Disponível no menu lateral como primeira opção (`Modo guiado`).

--- a/ogum-ml-lite/app/edu/__init__.py
+++ b/ogum-ml-lite/app/edu/__init__.py
@@ -1,0 +1,10 @@
+"""Educational mode utilities for Ogum-ML Lite."""
+
+from . import components, exercises, exporter, simulators
+
+__all__ = [
+    "components",
+    "exercises",
+    "exporter",
+    "simulators",
+]

--- a/ogum-ml-lite/app/edu/components.py
+++ b/ogum-ml-lite/app/edu/components.py
@@ -1,0 +1,76 @@
+"""Reusable UI components for the Educational Mode."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import streamlit as st
+
+
+def card_conceito(title: str, md_text: str, formula_latex: str | None = None) -> None:
+    """Render a concept card with Markdown explanation and optional formula.
+
+    Parameters
+    ----------
+    title:
+        Card title displayed in bold.
+    md_text:
+        Markdown string with the conceptual explanation in pt/en.
+    formula_latex:
+        Optional LaTeX expression rendered below the body using Streamlit's MathJax.
+    """
+
+    with st.container(border=True):
+        st.markdown(f"### {title}")
+        st.markdown(md_text, unsafe_allow_html=False)
+        if formula_latex:
+            st.markdown("---")
+            st.latex(formula_latex)
+
+
+def callout(kind: Literal["info", "warn", "tip"], text: str) -> None:
+    """Render a lightweight callout for contextual hints.
+
+    Parameters
+    ----------
+    kind:
+        Type of callout. ``"info"`` uses an informational tone, ``"warn"`` warns the
+        learner and ``"tip"`` highlights practical suggestions.
+    text:
+        Markdown message rendered in the callout body.
+    """
+
+    renderers = {
+        "info": st.info,
+        "warn": st.warning,
+        "tip": st.success,
+    }
+    renderer = renderers.get(kind, st.info)
+    renderer(text)
+
+
+def figure_plotly(fig, caption: str) -> None:
+    """Display a Plotly figure with a caption.
+
+    Parameters
+    ----------
+    fig:
+        Plotly ``Figure`` instance already configured by the simulator.
+    caption:
+        Text explaining what the learner should observe in the chart.
+    """
+
+    st.plotly_chart(fig, use_container_width=True)
+    st.caption(caption)
+
+
+def formula_block(latex: str) -> None:
+    """Render a LaTeX formula using Streamlit's MathJax support.
+
+    Parameters
+    ----------
+    latex:
+        LaTeX expression displayed as a standalone block.
+    """
+
+    st.latex(latex)

--- a/ogum-ml-lite/app/edu/exercises.py
+++ b/ogum-ml-lite/app/edu/exercises.py
@@ -1,0 +1,196 @@
+"""Guided exercises for the Educational Mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+import numpy as np
+
+from . import simulators
+
+
+@dataclass
+class Exercise:
+    """Metadata and evaluation logic for an educational exercise."""
+
+    key: str
+    statement_md: str
+    inputs_spec: Mapping[str, Mapping[str, str]]
+    evaluate: Callable[[Mapping[str, float]], dict]
+
+
+def _generate_curves() -> list[dict]:
+    time = np.linspace(0, 1800, 200)
+    base_temp = 950 + 120 * np.sin(np.linspace(0, np.pi, time.size))
+    offsets = (-40, 0, 45)
+    curves: list[dict] = []
+    for idx, offset in enumerate(offsets, start=1):
+        temp = base_temp + offset
+        theta = simulators.simulate_theta(temp, time, 320.0)
+        theta_norm = theta / theta[-1]
+        densification = 0.45 + 0.5 * np.power(theta_norm, 1.4 + 0.1 * idx)
+        curves.append(
+            {
+                "time_s": time,
+                "temp_C": temp,
+                "y": densification,
+                "label": f"Amostra {idx}",
+            }
+        )
+    return curves
+
+
+_CURVES = _generate_curves()
+_COLLAPSE_TARGET = simulators.simulate_msc_collapse(_CURVES, 320.0)
+_MEAN_THETA = _COLLAPSE_TARGET.grid_theta
+_MEAN_Y = _COLLAPSE_TARGET.mean_curve
+_SEGMENT_REFERENCES = {
+    55: float(np.interp(0.55, _MEAN_Y, _MEAN_THETA)),
+    70: float(np.interp(0.70, _MEAN_Y, _MEAN_THETA)),
+    90: float(np.interp(0.90, _MEAN_Y, _MEAN_THETA)),
+}
+_BLAINE_REFERENCE = simulators.simulate_blaine_linearization(
+    theta=_COLLAPSE_TARGET.grid_theta + 1e-6, y=_COLLAPSE_TARGET.mean_curve
+)
+
+
+def exercise_choose_ea() -> Exercise:
+    """Exercise that asks the learner to tune the activation energy."""
+
+    statement = (
+        "**Escolha de Ea / Choosing Ea**\n\n"
+        "Ajuste o valor de Ea (kJ/mol) para que as curvas colapsadas tenham o menor "
+        "erro médio. Use a simulação acima como referência."
+    )
+    inputs = {"Ea": {"label": "Ea (kJ/mol)", "type": "number"}}
+
+    def _evaluate(payload: Mapping[str, float]) -> dict:
+        try:
+            candidate = float(payload.get("Ea", 0))
+        except (TypeError, ValueError):
+            return {"score": 0.0, "feedback": "Informe um número válido para Ea."}
+        result = simulators.simulate_msc_collapse(_CURVES, candidate)
+        baseline = _COLLAPSE_TARGET.mse
+        delta = abs(result.mse - baseline)
+        score = max(0.0, 1.0 - delta / max(baseline, 1e-6))
+        feedback = (
+            f"MSE obtido: {result.mse:.4f}. O valor de referência está em torno de "
+            f"{baseline:.4f}."
+        )
+        return {"score": round(score, 3), "feedback": feedback}
+
+    return Exercise(
+        key="choose_ea",
+        statement_md=statement,
+        inputs_spec=inputs,
+        evaluate=_evaluate,
+    )
+
+
+def exercise_segments() -> Exercise:
+    """Exercise about locating the 55–70–90% densification segments."""
+
+    statement = (
+        "**Segmentos 55–70–90 / 55–70–90 segments**\n\n"
+        "Indique os valores de Θ normalizado quando a densificação atinge 55%, 70% e "
+        "90%. Tolerância de ±0.03."
+    )
+    inputs = {
+        "seg_55": {"label": "Θ @55%", "type": "number"},
+        "seg_70": {"label": "Θ @70%", "type": "number"},
+        "seg_90": {"label": "Θ @90%", "type": "number"},
+    }
+
+    def _evaluate(payload: Mapping[str, float]) -> dict:
+        tolerance = 0.03
+        hits = 0
+        feedback_lines = []
+        for level in (55, 70, 90):
+            key = f"seg_{level}"
+            try:
+                guess = float(payload.get(key, np.nan))
+            except (TypeError, ValueError):
+                guess = np.nan
+            reference = _SEGMENT_REFERENCES[level]
+            if np.isnan(guess):
+                feedback_lines.append(f"{level}%: valor inválido.")
+                continue
+            error = abs(guess - reference)
+            if error <= tolerance:
+                hits += 1
+                feedback_lines.append(f"{level}%: ok (erro {error:.3f}).")
+            else:
+                feedback_lines.append(
+                    f"{level}%: fora da tolerância (referência {reference:.3f})."
+                )
+        score = hits / 3
+        return {"score": round(score, 3), "feedback": " ".join(feedback_lines)}
+
+    return Exercise(
+        key="segments",
+        statement_md=statement,
+        inputs_spec=inputs,
+        evaluate=_evaluate,
+    )
+
+
+def exercise_blaine_n() -> Exercise:
+    """Exercise about estimating ``n`` through Blaine linearisation."""
+
+    statement = (
+        "**Expoente n de Blaine / Blaine exponent n**\n\n"
+        "Utilize o ajuste linear em ln(Θ) × ln(y) para estimar n. Compare com o "
+        "referencial do modo educativo."
+    )
+    inputs = {"n": {"label": "n", "type": "number"}}
+
+    def _evaluate(payload: Mapping[str, float]) -> dict:
+        try:
+            guess = float(payload.get("n", 0.0))
+        except (TypeError, ValueError):
+            return {"score": 0.0, "feedback": "Informe um valor numérico para n."}
+        reference = _BLAINE_REFERENCE.n_est
+        error = abs(guess - reference)
+        tolerance = 0.1
+        score = max(0.0, 1.0 - error / tolerance)
+        feedback = f"n estimado: {guess:.3f}. Referência: {reference:.3f}."
+        return {"score": round(score, 3), "feedback": feedback}
+
+    return Exercise(
+        key="blaine_n",
+        statement_md=statement,
+        inputs_spec=inputs,
+        evaluate=_evaluate,
+    )
+
+
+EXERCISES = [exercise_choose_ea(), exercise_segments(), exercise_blaine_n()]
+
+
+def get_reference_curves() -> list[dict]:
+    """Return deep copies of the reference curves used in the exercises."""
+
+    curves: list[dict] = []
+    for payload in _CURVES:
+        curves.append(
+            {
+                "time_s": np.array(payload["time_s"], copy=True),
+                "temp_C": np.array(payload["temp_C"], copy=True),
+                "y": np.array(payload["y"], copy=True),
+                "label": payload["label"],
+            }
+        )
+    return curves
+
+
+def get_references() -> dict[str, float]:
+    """Expose key reference values used across the educational mode."""
+
+    return {
+        "ea": 320.0,
+        "seg_55": _SEGMENT_REFERENCES[55],
+        "seg_70": _SEGMENT_REFERENCES[70],
+        "seg_90": _SEGMENT_REFERENCES[90],
+        "n": _BLAINE_REFERENCE.n_est,
+    }

--- a/ogum-ml-lite/app/edu/exporter.py
+++ b/ogum-ml-lite/app/edu/exporter.py
@@ -1,0 +1,194 @@
+"""Export utilities for the Educational Mode."""
+
+from __future__ import annotations
+
+import base64
+import io
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+import markdown2
+
+try:  # pragma: no cover - optional dependency
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.units import cm
+    from reportlab.lib.utils import ImageReader
+    from reportlab.pdfgen import canvas
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    canvas = None
+    A4 = None
+    cm = None
+    ImageReader = None
+
+
+def capture_fig(fig: Any) -> bytes:
+    """Capture a Plotly figure as PNG if possible, otherwise as HTML bytes."""
+
+    try:
+        return fig.to_image(format="png")
+    except Exception:  # pragma: no cover - depends on kaleido availability
+        html = fig.to_html(full_html=False, include_plotlyjs="cdn")
+        return html.encode("utf-8")
+
+
+def _markdown_to_html(md_text: str) -> str:
+    return markdown2.markdown(md_text, extras=["fenced-code-blocks", "tables"])
+
+
+def export_html(
+    context: Mapping[str, Any], figures: Mapping[str, bytes], out_path: Path
+) -> Path:
+    """Generate a static HTML report for the educational flow."""
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    title = context.get("title", "Ogum-ML — Modo Educacional")
+    concepts = context.get("concepts", [])
+    simulations = context.get("simulations", [])
+    exercises = context.get("exercises", [])
+
+    body: list[str] = [f"<h1>{title}</h1>"]
+
+    if concepts:
+        body.append("<section><h2>Conceitos / Concepts</h2>")
+        for item in concepts:
+            body.append(f"<h3>{item.get('title')}</h3>")
+            body.append(_markdown_to_html(item.get("body", "")))
+            formula = item.get("formula")
+            if formula:
+                body.append(f"<p><em>{formula}</em></p>")
+        body.append("</section>")
+
+    if simulations:
+        body.append("<section><h2>Simulações</h2>")
+        for item in simulations:
+            body.append(f"<h3>{item.get('title')}</h3>")
+            body.append(_markdown_to_html(item.get("body", "")))
+            fig_key = item.get("figure_key")
+            if fig_key and fig_key in figures:
+                body.append(_embed_figure(figures[fig_key]))
+        body.append("</section>")
+
+    if exercises:
+        body.append("<section><h2>Exercícios / Exercises</h2>")
+        for ex in exercises:
+            body.append(f"<h3>{ex.get('title')}</h3>")
+            body.append(_markdown_to_html(ex.get("statement", "")))
+            answer = ex.get("answer")
+            if answer:
+                body.append(f"<p><strong>Resposta:</strong> {answer}</p>")
+        body.append("</section>")
+
+    html = (
+        "<html><head><meta charset='utf-8'><title>{title}</title></head><body>"
+        f"{''.join(body)}</body></html>"
+    )
+    out_path.write_text(html, encoding="utf-8")
+    return out_path
+
+
+def _embed_figure(data: bytes) -> str:
+    if data.startswith(b"<"):
+        return data.decode("utf-8")
+    encoded = base64.b64encode(data).decode("ascii")
+    return (
+        "<figure><img src='data:image/png;base64,"
+        f"{encoded}' alt='Figura' style='max-width:100%'>"
+        "<figcaption></figcaption></figure>"
+    )
+
+
+def export_pdf(
+    context: Mapping[str, Any], figures: Mapping[str, bytes], out_path: Path
+) -> Path | None:
+    """Generate a lightweight PDF report if ReportLab is available."""
+
+    if canvas is None or A4 is None:
+        return None
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    title = context.get("title", "Ogum-ML — Modo Educacional")
+    c = canvas.Canvas(str(out_path), pagesize=A4)
+    width, height = A4
+    text = c.beginText(2 * cm, height - 2 * cm)
+    text.setFont("Helvetica-Bold", 16)
+    text.textLine(title)
+    text.moveCursor(0, 12)
+    text.setFont("Helvetica", 11)
+
+    def _write_section(header: str, items: list[dict]) -> None:
+        nonlocal text
+        if not items:
+            return
+        text.setFont("Helvetica-Bold", 13)
+        text.textLine(header)
+        text.setFont("Helvetica", 11)
+        for item in items:
+            _write_wrapped(text, item.get("title", ""), bullet=True)
+            statement = item.get("statement") or item.get("body") or ""
+            if statement:
+                _write_wrapped(text, _html_to_text(_markdown_to_html(statement)))
+            answer = item.get("answer")
+            if answer:
+                _write_wrapped(text, f"Resposta: {answer}")
+        text.moveCursor(0, 12)
+
+    concepts = context.get("concepts", [])
+    simulations = context.get("simulations", [])
+    exercises = context.get("exercises", [])
+
+    _write_section("Conceitos", concepts)
+    _write_section("Simulações", simulations)
+    _write_section("Exercícios", exercises)
+    c.drawText(text)
+
+    y_cursor = text.getY() - 20
+    for key, data in figures.items():
+        image = _to_image(data)
+        if image is None:
+            continue
+        img_width, img_height = image.getSize()
+        scale = min((width - 4 * cm) / img_width, 10 * cm / img_height)
+        if y_cursor - img_height * scale < 2 * cm:
+            c.showPage()
+            y_cursor = height - 2 * cm
+        c.drawImage(
+            image,
+            2 * cm,
+            y_cursor - img_height * scale,
+            width=img_width * scale,
+            height=img_height * scale,
+        )
+        y_cursor -= img_height * scale + 20
+
+    c.showPage()
+    c.save()
+    return out_path
+
+
+def _write_wrapped(text_obj, message: str, bullet: bool = False) -> None:
+    if not message:
+        return
+    max_width = 85
+    words = message.split()
+    line = "• " if bullet else ""
+    while words:
+        word = words.pop(0)
+        if len(line + word) > max_width:
+            text_obj.textLine(line.rstrip())
+            line = "  " if bullet else ""
+        line += word + " "
+    if line.strip():
+        text_obj.textLine(line.rstrip())
+
+
+def _html_to_text(html: str) -> str:
+    return re.sub(r"<[^>]+>", "", html)
+
+
+def _to_image(data: bytes):  # pragma: no cover - trivial glue
+    if ImageReader is None:
+        return None
+    if data.startswith(b"<"):
+        return None
+    return ImageReader(io.BytesIO(data))

--- a/ogum-ml-lite/app/edu/simulators.py
+++ b/ogum-ml-lite/app/edu/simulators.py
@@ -1,0 +1,265 @@
+"""Educational simulators for the training mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+import plotly.graph_objects as go
+
+R_GAS = 8.314  # J/(mol*K)
+
+
+@dataclass
+class CollapseResult:
+    """Container with results of the MSC collapse simulation."""
+
+    grid_theta: np.ndarray
+    mean_curve: np.ndarray
+    mse: float
+    collapsed_curves: list[dict]
+    figure: go.Figure
+
+
+@dataclass
+class BlaineResult:
+    """Container with the Blaine linearisation output."""
+
+    n_est: float
+    r2: float
+    mse: float
+    log_theta: np.ndarray
+    log_y: np.ndarray
+    figure: go.Figure
+
+
+def simulate_theta(
+    temp_profile_C: np.ndarray,
+    time_s: np.ndarray,
+    Ea_kJ: float,
+) -> np.ndarray:
+    r"""Compute the discrete Arrhenius integral :math:`\Theta(t)`.
+
+    Parameters
+    ----------
+    temp_profile_C:
+        Temperature profile in Celsius degrees for each timestamp.
+    time_s:
+        Time samples in seconds, strictly increasing.
+    Ea_kJ:
+        Activation energy expressed in kJ/mol.
+
+    Returns
+    -------
+    np.ndarray
+        Array with the cumulative Arrhenius integral for each instant.
+    """
+
+    temps_K = np.asarray(temp_profile_C, dtype=float) + 273.15
+    time_s = np.asarray(time_s, dtype=float)
+    if temps_K.shape != time_s.shape:
+        raise ValueError("Temperature and time arrays must have the same shape")
+    if temps_K.ndim != 1:
+        raise ValueError("Temperature and time arrays must be one-dimensional")
+    if np.any(np.diff(time_s) <= 0):
+        raise ValueError("time_s must be strictly increasing")
+
+    ea_j = Ea_kJ * 1_000.0
+    k = np.exp(-ea_j / (R_GAS * temps_K))
+    increments = np.concatenate(([0.0], 0.5 * (k[1:] + k[:-1]) * np.diff(time_s)))
+    theta = np.cumsum(increments)
+    theta -= theta.min()
+    return theta
+
+
+def make_fig_theta(
+    time_s: np.ndarray, temp_C: np.ndarray, theta: np.ndarray
+) -> go.Figure:
+    r"""Build a dual-axis plot showing the thermal cycle and :math:`\Theta(t)`."""
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(x=time_s, y=temp_C, mode="lines", name="T (°C)", yaxis="y1")
+    )
+    fig.add_trace(go.Scatter(x=time_s, y=theta, mode="lines", name="Θ", yaxis="y2"))
+    fig.update_layout(
+        xaxis_title="t (s)",
+        yaxis=dict(title="T (°C)", rangemode="tozero"),
+        yaxis2=dict(
+            title="Θ", overlaying="y", side="right", showgrid=False, rangemode="tozero"
+        ),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+        template="plotly_white",
+    )
+    return fig
+
+
+def _prepare_curve(curve: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray, str]:
+    time = np.asarray(curve["time_s"], dtype=float)
+    temp = np.asarray(curve["temp_C"], dtype=float)
+    y = np.asarray(curve["y"], dtype=float)
+    label = str(curve.get("label", "sample"))
+    return time, temp, y, label
+
+
+def simulate_msc_collapse(curves: Sequence[dict], Ea_kJ: float) -> CollapseResult:
+    """Collapse multiple densification curves using the Arrhenius time.
+
+    Parameters
+    ----------
+    curves:
+        Sequence of dictionaries with ``time_s``, ``temp_C`` and ``y`` arrays.
+    Ea_kJ:
+        Candidate activation energy in kJ/mol.
+
+    Returns
+    -------
+    CollapseResult
+        Structured result with the collapsed curves, MSE and Plotly figure.
+    """
+
+    collapsed: list[dict] = []
+    grid = np.linspace(0.0, 1.0, 200)
+    interpolated: list[np.ndarray] = []
+
+    for curve in curves:
+        time, temp, y, label = _prepare_curve(curve)
+        theta = simulate_theta(temp, time, Ea_kJ)
+        theta_norm = theta / theta[-1] if theta[-1] != 0 else theta
+        y_interp = np.interp(grid, theta_norm, y)
+        collapsed.append(
+            {
+                "theta_norm": theta_norm,
+                "y": y,
+                "time_s": time,
+                "label": label,
+            }
+        )
+        interpolated.append(y_interp)
+
+    stacked = np.vstack(interpolated)
+    mean_curve = np.mean(stacked, axis=0)
+    mse = float(np.mean((stacked - mean_curve) ** 2))
+    figure = make_fig_collapse(
+        grid,
+        stacked,
+        mean_curve,
+        [c["label"] for c in collapsed],
+    )
+    return CollapseResult(
+        grid_theta=grid,
+        mean_curve=mean_curve,
+        mse=mse,
+        collapsed_curves=collapsed,
+        figure=figure,
+    )
+
+
+def make_fig_collapse(
+    grid_theta: np.ndarray,
+    collapsed_y: Iterable[np.ndarray],
+    mean_curve: np.ndarray,
+    labels: Sequence[str],
+) -> go.Figure:
+    """Create a Plotly figure with the collapsed MSC curves."""
+
+    fig = go.Figure()
+    for series, label in zip(collapsed_y, labels):
+        fig.add_trace(
+            go.Scatter(
+                x=grid_theta,
+                y=series,
+                mode="lines",
+                name=label,
+                hovertemplate="Θ: %{x:.2f}<br>y: %{y:.3f}<extra></extra>",
+            )
+        )
+    fig.add_trace(
+        go.Scatter(
+            x=grid_theta,
+            y=mean_curve,
+            mode="lines",
+            name="média",
+            line=dict(width=4, dash="dash"),
+        )
+    )
+    fig.update_layout(
+        template="plotly_white",
+        xaxis_title="Θ normalizado",
+        yaxis_title="Densificação",
+    )
+    return fig
+
+
+def simulate_blaine_linearization(theta: np.ndarray, y: np.ndarray) -> BlaineResult:
+    """Estimate ``n`` via Blaine linearisation from Arrhenius time and densification.
+
+    Parameters
+    ----------
+    theta:
+        Arrhenius time vector (positive values).
+    y:
+        Densification response aligned with ``theta``.
+
+    Returns
+    -------
+    BlaineResult
+        Result object containing the estimated ``n`` and diagnostic metrics.
+    """
+
+    theta = np.asarray(theta, dtype=float)
+    y = np.asarray(y, dtype=float)
+    if theta.shape != y.shape:
+        raise ValueError("theta and y must have the same shape")
+    mask = (theta > 0) & (y > 0)
+    if mask.sum() < 2:
+        raise ValueError("Need at least two valid samples for Blaine linearisation")
+    theta = theta[mask]
+    y = y[mask]
+
+    log_theta = np.log(theta)
+    log_y = np.log(y)
+    slope, intercept = np.polyfit(log_theta, log_y, 1)
+    y_pred = np.exp(intercept + slope * log_theta)
+    residuals = y - y_pred
+    mse = float(np.mean(residuals**2))
+    ss_res = float(np.sum(residuals**2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot != 0 else 0.0
+    figure = make_fig_blaine(log_theta, log_y, slope, intercept)
+    return BlaineResult(
+        n_est=float(slope),
+        r2=float(max(min(r2, 1.0), 0.0)),
+        mse=mse,
+        log_theta=log_theta,
+        log_y=log_y,
+        figure=figure,
+    )
+
+
+def make_fig_blaine(
+    log_theta: np.ndarray, log_y: np.ndarray, slope: float, intercept: float
+) -> go.Figure:
+    """Plot the Blaine linearisation along with the fitted line."""
+
+    x_sorted = np.linspace(log_theta.min(), log_theta.max(), 100)
+    y_line = intercept + slope * x_sorted
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=log_theta,
+            y=log_y,
+            mode="markers",
+            name="dados",
+            hovertemplate="ln Θ: %{x:.2f}<br>ln y: %{y:.2f}<extra></extra>",
+        )
+    )
+    fig.add_trace(go.Scatter(x=x_sorted, y=y_line, mode="lines", name="ajuste"))
+    fig.update_layout(
+        template="plotly_white",
+        xaxis_title="ln Θ",
+        yaxis_title="ln densificação",
+    )
+    return fig

--- a/ogum-ml-lite/app/i18n/locales/en.json
+++ b/ogum-ml-lite/app/i18n/locales/en.json
@@ -12,7 +12,8 @@
     "mechanism": "Mechanism",
     "ml": "ML Models",
     "export": "Export",
-    "jobs": "Jobs Monitor"
+    "jobs": "Jobs Monitor",
+    "edu": "Educational mode"
   },
   "workspace": {
     "title": "Workspace",
@@ -149,5 +150,81 @@
     "describe_segments": "Segments: table with fractions per stage.",
     "describe_mechanism": "Mechanism: report with τ, R² and detected thresholds.",
     "describe_ml": "ML: cross-validation metrics per model."
+  }
+  ,
+  "edu": {
+    "title": "Educational mode",
+    "intro": "Learn θ, MSC collapse and Blaine n with guided visuals, bilingual copy and auto-graded exercises.",
+    "steps": {
+      "load": {
+        "title": "1. Load data",
+        "hint": "Upload a long-format CSV or reuse the sample to practice."
+      },
+      "simulate": {
+        "title": "2. θ, MSC & n",
+        "hint": "Use the controls to tune Ea, collapse curves and run the Blaine linearisation."
+      },
+      "explore": {
+        "title": "3. Explore & export",
+        "hint": "Answer the guided exercises and export an educational summary."
+      }
+    },
+    "labels": {
+      "upload": "Upload long CSV",
+      "dataset_select": "Select dataset",
+      "ea_slider": "Ea (kJ/mol)",
+      "seg_55": "Normalised Θ @55%",
+      "seg_70": "Normalised Θ @70%",
+      "seg_90": "Normalised Θ @90%"
+    },
+    "actions": {
+      "validate": "Validate",
+      "prepare": "Prepare",
+      "compute_theta": "Compute θ",
+      "collapse_msc": "Collapse MSC",
+      "linearize_blaine": "Linearise Blaine",
+      "check": "Check answer",
+      "export_html": "Export educational HTML",
+      "export_pdf": "Export educational PDF",
+      "open_advanced": "Open advanced mode"
+    },
+    "cards": {
+      "theta": {
+        "title": "Why normalise time?",
+        "body": "θ accumulates the thermal effect via the Arrhenius integral, allowing comparable cycles. θ condenses temperature and time into a single scale.",
+        "formula": "\\Theta(t) = \\int_0^t e^{{-E_a/(R T(\\tau))}} d\\tau"
+      },
+      "blaine": {
+        "title": "Blaine linearisation",
+        "body": "Assuming y = k \\Theta^n, taking ln yields a straight line: ln(y) = ln(k) + n ln(\\Theta). The slope reveals n.",
+        "formula": "\\ln(y) = \\ln(k) + n\\,\\ln(\\Theta)"
+      }
+    },
+    "captions": {
+      "theta": "θ tracks the accumulated thermal cycle.",
+      "collapse": "Curves collapsed by normalised θ.",
+      "blaine": "ln(θ) × ln(y) plot with linear fit."
+    },
+    "messages": {
+      "upload_success": "[ok] {name} stored in the workspace.",
+      "load_failed": "[warn] Failed to load dataset: {error}",
+      "dataset_missing": "[warn] File not found.",
+      "validation_ok": "[ok] Dataset validated.",
+      "validation_warn": "[warn] Validation reported warnings.",
+      "prep_running": "Running educational prep...",
+      "prep_ok": "[ok] {name} generated.",
+      "prep_failed": "[warn] Could not prepare the data.",
+      "need_dataset": "Upload or pick a dataset first.",
+      "extract_failed": "Could not build the curves: {error}",
+      "need_collapse": "Run the MSC collapse before linearising.",
+      "export_hint": "Complete the exercises and export to review with your team.",
+      "sim_theta": "θ computed with Ea = {ea:.1f} kJ/mol.",
+      "sim_collapse": "MSC collapse using θ normalisation.",
+      "sim_blaine": "Blaine linearisation and n estimate.",
+      "exercise_title": "Answered exercises",
+      "export_running": "Building educational material...",
+      "export_ok": "[ok] {name} created.",
+      "pdf_missing": "ReportLab not installed — export HTML or install the [pdf] extra."
+    }
   }
 }

--- a/ogum-ml-lite/app/i18n/locales/pt.json
+++ b/ogum-ml-lite/app/i18n/locales/pt.json
@@ -12,7 +12,8 @@
     "mechanism": "Mecanismo",
     "ml": "Modelos ML",
     "export": "Exportar",
-    "jobs": "Jobs Monitor"
+    "jobs": "Jobs Monitor",
+    "edu": "Modo Educacional"
   },
   "workspace": {
     "title": "Workspace",
@@ -149,5 +150,81 @@
     "describe_segments": "Segmentos: tabela com frações por estágio.",
     "describe_mechanism": "Mecanismo: relatório com τ, R² e limiares detectados.",
     "describe_ml": "ML: métricas de validação cruzada por modelo."
+  }
+  ,
+  "edu": {
+    "title": "Modo Educacional",
+    "intro": "Aprenda os fundamentos de θ, MSC e n com visualizações, exercícios guiados e export educacional. Learn the essentials with guided microcopy.",
+    "steps": {
+      "load": {
+        "title": "1. Carregar Dados",
+        "hint": "Envie um CSV longo ou use o exemplo para praticar. Upload your dataset to start."
+      },
+      "simulate": {
+        "title": "2. θ, MSC & n",
+        "hint": "Explore os sliders e gráficos para ajustar Ea, colapso MSC e linearização de Blaine."
+      },
+      "explore": {
+        "title": "3. Explorar & Exportar",
+        "hint": "Resolva os exercícios, revise os resultados e exporte um resumo educacional."
+      }
+    },
+    "labels": {
+      "upload": "Enviar CSV longo / Upload CSV",
+      "dataset_select": "Selecionar dataset",
+      "ea_slider": "Ea (kJ/mol)",
+      "seg_55": "Θ normalizado @55%",
+      "seg_70": "Θ normalizado @70%",
+      "seg_90": "Θ normalizado @90%"
+    },
+    "actions": {
+      "validate": "Validar",
+      "prepare": "Preparar",
+      "compute_theta": "Calcular θ",
+      "collapse_msc": "Colapsar MSC",
+      "linearize_blaine": "Linearizar Blaine",
+      "check": "Checar resposta",
+      "export_html": "Exportar HTML Educacional",
+      "export_pdf": "Exportar PDF Educacional",
+      "open_advanced": "Abrir modo avançado"
+    },
+    "cards": {
+      "theta": {
+        "title": "Por que normalizar o tempo?",
+        "body": "O tempo θ acumula o efeito térmico via integral de Arrhenius, permitindo comparar ciclos diferentes. Theta condenses temperature/time into a comparable scale.",
+        "formula": "\\Theta(t) = \\int_0^t e^{{-E_a/(R T(\\tau))}} d\\tau"
+      },
+      "blaine": {
+        "title": "Linearização de Blaine",
+        "body": "Supondo y = k \\Theta^n, tomar ln transforma em linha reta: ln(y) = ln(k) + n ln(\\Theta). Ajuste linear revela o expoente n.",
+        "formula": "\\ln(y) = \\ln(k) + n\\,\\ln(\\Theta)"
+      }
+    },
+    "captions": {
+      "theta": "θ acompanha o ciclo térmico acumulado.",
+      "collapse": "Curvas colapsadas via θ normalizado.",
+      "blaine": "Linearização ln(θ) × ln(y) e ajuste de n."
+    },
+    "messages": {
+      "upload_success": "[ok] {name} salvo no workspace.",
+      "load_failed": "[warn] Falha ao carregar dataset: {error}",
+      "dataset_missing": "[warn] Arquivo não encontrado.",
+      "validation_ok": "[ok] Dataset válido.",
+      "validation_warn": "[warn] Validação encontrou avisos.",
+      "prep_running": "Executando preparação educacional...",
+      "prep_ok": "[ok] {name} gerado.",
+      "prep_failed": "[warn] Não foi possível preparar os dados.",
+      "need_dataset": "Envie ou selecione um dataset para continuar.",
+      "extract_failed": "Não foi possível montar as curvas: {error}",
+      "need_collapse": "Calcule o colapso MSC antes de linearizar.",
+      "export_hint": "Preencha os exercícios e exporte para revisar com a equipe.",
+      "sim_theta": "θ calculado com Ea = {ea:.1f} kJ/mol.",
+      "sim_collapse": "Colapso MSC com normalização por θ.",
+      "sim_blaine": "Linearização de Blaine com ajuste de n.",
+      "exercise_title": "Exercícios respondidos",
+      "export_running": "Gerando material educacional...",
+      "export_ok": "[ok] {name} criado.",
+      "pdf_missing": "ReportLab não instalado — gere HTML ou instale a dependência [pdf]."
+    }
   }
 }

--- a/ogum-ml-lite/app/page_edu.py
+++ b/ogum-ml-lite/app/page_edu.py
@@ -1,0 +1,375 @@
+"""Streamlit page for the educational mode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+from ogum_lite.ui.workspace import Workspace
+
+from app.edu import components, exercises, exporter, simulators
+from app.i18n.translate import I18N
+from app.services import run_cli, state, validators
+
+
+def _workspace_csvs(workspace: Workspace) -> list[Path]:
+    uploads = workspace.resolve("uploads")
+    if not uploads.exists():
+        return []
+    return sorted(uploads.glob("*.csv"))
+
+
+def _build_sample_dataset(workspace: state.Workspace) -> Path:
+    curves = exercises.get_reference_curves()
+    rows: list[dict[str, Any]] = []
+    for curve in curves:
+        for t, temp, y in zip(curve["time_s"], curve["temp_C"], curve["y"]):
+            rows.append(
+                {
+                    "sample_id": curve["label"],
+                    "time_s": float(t),
+                    "temp_C": float(temp),
+                    "rho_rel": float(y),
+                }
+            )
+    df = pd.DataFrame(rows)
+    target = workspace.resolve("edu_sample.csv")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(target, index=False)
+    return target
+
+
+def _load_dataset(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+
+def _extract_curves(df: pd.DataFrame) -> list[dict]:
+    expected = {"sample_id", "time_s", "temp_C", "rho_rel"}
+    if not expected.issubset(df.columns):
+        missing = ", ".join(sorted(expected - set(df.columns)))
+        raise ValueError(f"Missing required columns: {missing}")
+    curves = []
+    for sample_id, group in df.groupby("sample_id"):
+        ordered = group.sort_values("time_s")
+        curves.append(
+            {
+                "label": str(sample_id),
+                "time_s": ordered["time_s"].to_numpy(dtype=float),
+                "temp_C": ordered["temp_C"].to_numpy(dtype=float),
+                "y": ordered["rho_rel"].to_numpy(dtype=float),
+            }
+        )
+    return curves
+
+
+def _store_fig(session_key: str, fig) -> None:
+    st.session_state[session_key] = fig
+    st.session_state[f"{session_key}_bytes"] = exporter.capture_fig(fig)
+
+
+def _get_fig_bytes(session_key: str) -> bytes | None:
+    return st.session_state.get(f"{session_key}_bytes")
+
+
+def _render_dataset_step(translator: I18N) -> pd.DataFrame | None:
+    st.header(translator.t("edu.steps.load.title"))
+    st.caption(translator.t("edu.steps.load.hint"))
+
+    workspace = state.get_workspace()
+    sample_path = _build_sample_dataset(workspace)
+
+    uploaded = st.file_uploader(
+        translator.t("edu.labels.upload"),
+        type=["csv"],
+        key="edu_upload",
+    )
+    if uploaded is not None:
+        state.persist_upload(uploaded, subdir="uploads")
+        st.toast(translator.t("edu.messages.upload_success", name=uploaded.name))
+    csv_files = [sample_path] + _workspace_csvs(workspace)
+    options = {str(path): path for path in csv_files}
+    default_key = str(sample_path)
+    selection = st.selectbox(
+        translator.t("edu.labels.dataset_select"),
+        options=list(options.keys()),
+        format_func=lambda key: options[key].name,
+        index=list(options.keys()).index(default_key) if default_key in options else 0,
+        key="edu_dataset_option",
+    )
+    dataset_path = options.get(selection)
+    dataset_df: pd.DataFrame | None = None
+
+    if dataset_path and dataset_path.exists():
+        try:
+            dataset_df = _load_dataset(dataset_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            st.error(translator.t("edu.messages.load_failed", error=str(exc)))
+    else:
+        st.warning(translator.t("edu.messages.dataset_missing"))
+
+    cols = st.columns(2)
+    if dataset_path and cols[0].button(translator.t("edu.actions.validate")):
+        summary = validators.validate_long(dataset_path)
+        if summary.ok:
+            st.toast(translator.t("edu.messages.validation_ok"))
+        else:
+            st.toast(translator.t("edu.messages.validation_warn"))
+        for issue in summary.issues:
+            st.warning(issue)
+
+    if dataset_path and cols[1].button(translator.t("edu.actions.prepare")):
+        preset = state.get_preset()
+        with st.spinner(translator.t("edu.messages.prep_running")):
+            result = run_cli.run_prep(dataset_path, preset, workspace)
+        prep_csv = result.outputs.get("prep_csv")
+        if prep_csv:
+            state.register_artifact("edu_prep_csv", prep_csv, description="edu")
+            st.toast(translator.t("edu.messages.prep_ok", name=prep_csv.name))
+        else:
+            st.error(translator.t("edu.messages.prep_failed"))
+
+    if dataset_df is not None:
+        st.dataframe(dataset_df.head(20))
+
+    components.card_conceito(
+        translator.t("edu.cards.theta.title"),
+        translator.t("edu.cards.theta.body"),
+        translator.t("edu.cards.theta.formula"),
+    )
+    return dataset_df
+
+
+def _render_simulation_step(
+    translator: I18N,
+    dataset_df: pd.DataFrame | None,
+) -> tuple[simulators.CollapseResult | None, simulators.BlaineResult | None, float]:
+    st.header(translator.t("edu.steps.simulate.title"))
+    st.caption(translator.t("edu.steps.simulate.hint"))
+
+    if dataset_df is None:
+        components.callout("warn", translator.t("edu.messages.need_dataset"))
+        return None, None, exercises.get_references()["ea"]
+
+    try:
+        curves = _extract_curves(dataset_df)
+    except ValueError as exc:
+        message = translator.t("edu.messages.extract_failed", error=str(exc))
+        components.callout("warn", message)
+        return None, None, exercises.get_references()["ea"]
+
+    references = exercises.get_references()
+    ea_default = st.session_state.get("edu_ea", references["ea"])
+    ea_value = st.slider(
+        translator.t("edu.labels.ea_slider"),
+        min_value=200.0,
+        max_value=400.0,
+        value=float(ea_default),
+        step=5.0,
+        key="edu_ea",
+    )
+
+    theta_container = st.container()
+    if st.button(translator.t("edu.actions.compute_theta")):
+        first_curve = curves[0]
+        theta = simulators.simulate_theta(
+            first_curve["temp_C"], first_curve["time_s"], ea_value
+        )
+        fig = simulators.make_fig_theta(
+            first_curve["time_s"], first_curve["temp_C"], theta
+        )
+        _store_fig("edu_theta_fig", fig)
+        with theta_container:
+            components.figure_plotly(fig, translator.t("edu.captions.theta"))
+    elif "edu_theta_fig" in st.session_state:
+        fig = st.session_state["edu_theta_fig"]
+        with theta_container:
+            components.figure_plotly(fig, translator.t("edu.captions.theta"))
+
+    cols = st.columns(3)
+    seg_inputs = {}
+    for idx, level in enumerate((55, 70, 90)):
+        seg_inputs[level] = cols[idx].number_input(
+            translator.t(f"edu.labels.seg_{level}"),
+            min_value=0.0,
+            max_value=1.0,
+            value=float(references[f"seg_{level}"]),
+            step=0.01,
+            key=f"edu_seg_{level}",
+        )
+
+    collapse_result = None
+    collapse_placeholder = st.container()
+    if st.button(translator.t("edu.actions.collapse_msc")):
+        collapse_result = simulators.simulate_msc_collapse(curves, ea_value)
+        st.session_state["edu_collapse"] = collapse_result
+        _store_fig("edu_collapse_fig", collapse_result.figure)
+        with collapse_placeholder:
+            components.figure_plotly(
+                collapse_result.figure, translator.t("edu.captions.collapse")
+            )
+        st.metric("MSE", f"{collapse_result.mse:.4f}")
+    elif "edu_collapse" in st.session_state:
+        collapse_result = st.session_state["edu_collapse"]
+        with collapse_placeholder:
+            components.figure_plotly(
+                collapse_result.figure, translator.t("edu.captions.collapse")
+            )
+        st.metric("MSE", f"{collapse_result.mse:.4f}")
+
+    blaine_result = None
+    blaine_placeholder = st.container()
+    if st.button(translator.t("edu.actions.linearize_blaine")):
+        target = collapse_result or st.session_state.get("edu_collapse")
+        if target is None:
+            components.callout("info", translator.t("edu.messages.need_collapse"))
+        else:
+            blaine_result = simulators.simulate_blaine_linearization(
+                target.grid_theta + 1e-6, target.mean_curve
+            )
+            st.session_state["edu_blaine"] = blaine_result
+            _store_fig("edu_blaine_fig", blaine_result.figure)
+            with blaine_placeholder:
+                components.figure_plotly(
+                    blaine_result.figure, translator.t("edu.captions.blaine")
+                )
+            st.metric("n", f"{blaine_result.n_est:.3f}")
+            st.metric("R²", f"{blaine_result.r2:.3f}")
+            st.metric("MSE", f"{blaine_result.mse:.4f}")
+    elif "edu_blaine" in st.session_state:
+        blaine_result = st.session_state["edu_blaine"]
+        with blaine_placeholder:
+            components.figure_plotly(
+                blaine_result.figure, translator.t("edu.captions.blaine")
+            )
+        st.metric("n", f"{blaine_result.n_est:.3f}")
+        st.metric("R²", f"{blaine_result.r2:.3f}")
+        st.metric("MSE", f"{blaine_result.mse:.4f}")
+
+    components.card_conceito(
+        translator.t("edu.cards.blaine.title"),
+        translator.t("edu.cards.blaine.body"),
+        translator.t("edu.cards.blaine.formula"),
+    )
+
+    st.session_state["edu_segments"] = seg_inputs
+    return collapse_result, blaine_result, ea_value
+
+
+def _render_explore_step(
+    translator: I18N,
+    collapse_result: simulators.CollapseResult | None,
+    blaine_result: simulators.BlaineResult | None,
+    ea_value: float,
+) -> None:
+    st.header(translator.t("edu.steps.explore.title"))
+    st.caption(translator.t("edu.steps.explore.hint"))
+
+    answers = st.session_state.setdefault("edu_answers", {})
+    results = []
+    for exercise in exercises.EXERCISES:
+        st.markdown(exercise.statement_md)
+        inputs_payload = {}
+        cols = st.columns(len(exercise.inputs_spec))
+        for idx, (key, spec) in enumerate(exercise.inputs_spec.items()):
+            default_value = answers.get(exercise.key, {}).get(key, 0.0)
+            inputs_payload[key] = cols[idx].number_input(
+                spec.get("label", key),
+                value=float(default_value),
+            )
+        if st.button(translator.t("edu.actions.check"), key=f"check_{exercise.key}"):
+            outcome = exercise.evaluate(inputs_payload)
+            answers.setdefault(exercise.key, {})
+            answers[exercise.key].update(inputs_payload)
+            answers[exercise.key]["score"] = outcome["score"]
+            answers[exercise.key]["feedback"] = outcome["feedback"]
+            st.session_state["edu_answers"] = answers
+        stored = answers.get(exercise.key, {})
+        if stored.get("feedback"):
+            st.info(f"Score {stored['score']:.2f} — {stored['feedback']}")
+        results.append(
+            {
+                "title": exercise.statement_md.split("\n", 1)[0],
+                "statement": exercise.statement_md,
+                "answer": stored,
+            }
+        )
+        st.divider()
+
+    components.callout("tip", translator.t("edu.messages.export_hint"))
+
+    figures = {}
+    for key in ("edu_theta_fig", "edu_collapse_fig", "edu_blaine_fig"):
+        fig_bytes = _get_fig_bytes(key)
+        if fig_bytes:
+            figures[key] = fig_bytes
+
+    context = {
+        "title": translator.t("edu.title"),
+        "concepts": [
+            {
+                "title": translator.t("edu.cards.theta.title"),
+                "body": translator.t("edu.cards.theta.body"),
+                "formula": translator.t("edu.cards.theta.formula"),
+            }
+        ],
+        "simulations": [
+            {
+                "title": translator.t("edu.captions.theta"),
+                "body": translator.t("edu.messages.sim_theta", ea=ea_value),
+                "figure_key": "edu_theta_fig",
+            },
+            {
+                "title": translator.t("edu.captions.collapse"),
+                "body": translator.t("edu.messages.sim_collapse"),
+                "figure_key": "edu_collapse_fig",
+            },
+            {
+                "title": translator.t("edu.captions.blaine"),
+                "body": translator.t("edu.messages.sim_blaine"),
+                "figure_key": "edu_blaine_fig",
+            },
+        ],
+        "exercises": [
+            {
+                "title": translator.t("edu.messages.exercise_title"),
+                "statement": item["statement"],
+                "answer": item["answer"],
+            }
+            for item in results
+        ],
+    }
+
+    export_dir = state.get_workspace().resolve("edu_exports")
+    html_path = export_dir / "modo_educacional.html"
+    if st.button(translator.t("edu.actions.export_html")):
+        with st.spinner(translator.t("edu.messages.export_running")):
+            exporter.export_html(context, figures, html_path)
+        st.toast(translator.t("edu.messages.export_ok", name=html_path.name))
+
+    if st.button(translator.t("edu.actions.export_pdf")):
+        with st.spinner(translator.t("edu.messages.export_running")):
+            pdf_path = export_dir / "modo_educacional.pdf"
+            result = exporter.export_pdf(context, figures, pdf_path)
+        if result is None:
+            components.callout("warn", translator.t("edu.messages.pdf_missing"))
+        else:
+            st.toast(translator.t("edu.messages.export_ok", name=pdf_path.name))
+
+    if st.button(translator.t("edu.actions.open_advanced")):
+        st.session_state["main_menu"] = "wizard"
+        st.experimental_rerun()
+
+
+def render(translator: I18N) -> None:
+    """Render the Educational Mode page."""
+
+    st.subheader(translator.t("edu.title"))
+    st.write(translator.t("edu.intro"))
+
+    dataset_df = _render_dataset_step(translator)
+    collapse_result, blaine_result, ea_value = _render_simulation_step(
+        translator, dataset_df
+    )
+    _render_explore_step(translator, collapse_result, blaine_result, ea_value)

--- a/ogum-ml-lite/app/streamlit_app.py
+++ b/ogum-ml-lite/app/streamlit_app.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 import streamlit as st
 
+from app import page_edu
 from app.design.ab_variants import EXPERIMENTS
 from app.design.layout import render_shell
 from app.i18n.translate import I18N
@@ -23,6 +24,7 @@ from app.pages import (
 from app.services import ab, state, telemetry
 
 PAGES: dict[str, tuple[str, Callable[[I18N], None]]] = {
+    "edu": ("menu.edu", page_edu.render),
     "wizard": ("menu.wizard", page_wizard.render),
     "prep": ("menu.prep", page_prep.render),
     "features": ("menu.features", page_features.render),

--- a/ogum-ml-lite/pyproject.toml
+++ b/ogum-ml-lite/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "requests",
     "xlrd",
     "pyyaml",
+    "markdown2>=2.4,<3",
 ]
 
 classifiers = [
@@ -55,6 +56,7 @@ lgbm = ["lightgbm>=4,<5"]
 cat = ["catboost>=1.2,<2"]
 xgb = ["xgboost>=2,<3"]
 sim = ["meshio>=5,<6"]
+pdf = ["reportlab>=4,<5"]
 
 [tool.setuptools.packages.find]
 include = ["ogum_lite", "app", "server"]

--- a/ogum-ml-lite/tests/test_edu_exercises.py
+++ b/ogum-ml-lite/tests/test_edu_exercises.py
@@ -1,0 +1,36 @@
+from app.edu import exercises
+
+
+def _get(key: str):
+    return next(ex for ex in exercises.EXERCISES if ex.key == key)
+
+
+def test_choose_ea_scoring():
+    ex = _get("choose_ea")
+    good = ex.evaluate({"Ea": 320.0})
+    poor = ex.evaluate({"Ea": 100.0})
+    assert good["score"] >= poor["score"]
+    assert "MSE" in good["feedback"]
+
+
+def test_segments_tolerance():
+    ex = _get("segments")
+    refs = exercises.get_references()
+    answers = {
+        "seg_55": refs["seg_55"],
+        "seg_70": refs["seg_70"],
+        "seg_90": refs["seg_90"],
+    }
+    result = ex.evaluate(answers)
+    assert result["score"] == 1.0
+    off = ex.evaluate({"seg_55": 0.0, "seg_70": 0.0, "seg_90": 0.0})
+    assert off["score"] < 1.0
+
+
+def test_blaine_error_metric():
+    ex = _get("blaine_n")
+    refs = exercises.get_references()
+    good = ex.evaluate({"n": refs["n"]})
+    bad = ex.evaluate({"n": refs["n"] + 1.0})
+    assert good["score"] > bad["score"]
+    assert "Referência" in good["feedback"]

--- a/ogum-ml-lite/tests/test_edu_export.py
+++ b/ogum-ml-lite/tests/test_edu_export.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import plotly.graph_objects as go
+from app.edu import exporter
+
+
+def _context() -> dict:
+    return {
+        "title": "Edu",
+        "concepts": [{"title": "Theta", "body": "**demo**", "formula": "x"}],
+        "simulations": [{"title": "Sim", "body": "text", "figure_key": "fig1"}],
+        "exercises": [{"title": "Ex", "statement": "desc", "answer": {"score": 1.0}}],
+    }
+
+
+def test_export_html_generates_file(tmp_path: Path) -> None:
+    fig = go.Figure(data=go.Scatter(x=[0, 1], y=[0, 1]))
+    figures = {"fig1": exporter.capture_fig(fig)}
+    target = tmp_path / "edu.html"
+    path = exporter.export_html(_context(), figures, target)
+    assert path.exists()
+    content = path.read_text(encoding="utf-8")
+    assert "Conceitos" in content
+
+
+def test_export_pdf_optional(tmp_path: Path) -> None:
+    target = tmp_path / "edu.pdf"
+    result = exporter.export_pdf(_context(), {}, target)
+    if result is None:
+        assert not target.exists()
+    else:
+        assert target.exists()

--- a/ogum-ml-lite/tests/test_edu_simulators.py
+++ b/ogum-ml-lite/tests/test_edu_simulators.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from app.edu import simulators
+
+
+def _sample_curves():
+    time = np.linspace(0, 1000, 50)
+    temps = [900 + 50 * np.sin(time / 200 + phase) for phase in (0.0, 0.4, 0.8)]
+    curves = []
+    for idx, temp in enumerate(temps, start=1):
+        theta = simulators.simulate_theta(temp, time, 320.0)
+        y = 0.5 + 0.4 * np.power(theta / theta[-1], 1.2 + 0.1 * idx)
+        curves.append(
+            {
+                "time_s": time,
+                "temp_C": temp,
+                "y": y,
+                "label": f"sample {idx}",
+            }
+        )
+    return curves
+
+
+def test_simulate_theta_is_increasing():
+    time = np.linspace(0, 1000, 50)
+    temp = np.linspace(900, 1150, 50)
+    theta = simulators.simulate_theta(temp, time, 310.0)
+    assert np.all(np.diff(theta) >= 0)
+    assert theta.shape == time.shape
+
+
+def test_collapse_produces_mean_curve():
+    result = simulators.simulate_msc_collapse(_sample_curves(), 320.0)
+    assert result.mean_curve.shape == result.grid_theta.shape
+    assert result.mse >= 0
+    assert result.figure is not None
+
+
+def test_blaine_linearisation_metrics():
+    theta = np.linspace(0.01, 1.0, 100)
+    y = 0.6 * np.power(theta, 1.5)
+    result = simulators.simulate_blaine_linearization(theta, y)
+    assert 0 <= result.r2 <= 1
+    assert result.n_est == pytest.approx(1.5, abs=0.1)
+    assert result.figure is not None


### PR DESCRIPTION
## Summary
- add a new Streamlit "Modo Educacional" page with a three-step flow, bilingual copy and integration with the existing layout
- implement educational UI components, simulators, exercises and exporters (HTML/PDF) plus related translations and documentation
- extend automated coverage with dedicated simulator, exporter and exercise tests while updating dependencies for markdown2/reportlab

## Testing
- ruff check .
- black --check .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68df019a2f6483278f548ce2bd31297d