### PR TITLE
Add release readiness workflow and checker

### DIFF
--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -1,0 +1,70 @@
+name: Release Check (1.0 readiness)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  release-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip stack
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Sanity print deps being used
+        run: |
+          echo "PWD: $(pwd)"
+          ls -la
+          echo "----- requirements resolved by CI -----"
+          if [ -f requirements.txt ]; then echo ">>> requirements.txt"; cat requirements.txt; fi
+          if ls requirements/*.txt >/dev/null 2>&1; then for f in requirements/*.txt; do echo ">>> $f"; cat "$f"; done; fi
+          echo "--------------------------------------"
+
+      - name: Install project deps
+        run: |
+          pip install --no-cache-dir -r requirements.txt || pip install -r requirements.txt
+
+      - name: Install dev tools (ruff/black/pytest) if not included
+        run: |
+          python -m pip install --upgrade ruff black pytest
+
+      - name: Run release_check.py
+        run: |
+          python tools/release_check.py
+        continue-on-error: true
+
+      - name: Collect logs
+        if: always()
+        run: |
+          mkdir -p artifacts
+          cp -f release_check.log artifacts/ 2>/dev/null || true
+          cp -f release_summary.md artifacts/ 2>/dev/null || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-check-artifacts
+          path: artifacts/
+
+      - name: Job Summary
+        if: always()
+        run: |
+          if [ -f release_summary.md ]; then
+            echo "## Ogum-ML — Release 1.0 Readiness" >> $GITHUB_STEP_SUMMARY
+            cat release_summary.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No summary file found." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Ogum-ML 1.0
 
+[![Release Check](https://github.com/huyraestevao/ogum-ml/actions/workflows/release_check.yml/badge.svg)](https://github.com/huyraestevao/ogum-ml/actions/workflows/release_check.yml)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://huyraestevao.github.io/ogum-ml/)
 [![PyPI](https://img.shields.io/pypi/v/ogum-ml.svg)](https://pypi.org/project/ogum-ml/)
 [![Docker](https://img.shields.io/docker/pulls/huyraestevao/ogum-ml.svg)](https://hub.docker.com/r/huyraestevao/ogum-ml)

--- a/tools/release_check.py
+++ b/tools/release_check.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Ogum-ML — Release 1.0 readiness checker.
+
+Executa:
+1) Upgrade de pip/setuptools/wheel (feito no workflow).
+2) Instalação de requirements.
+3) Checagem de pins legados (pydantic<2, pydantic-settings<2, pyyaml<6).
+4) Lint: ruff.
+5) Formatação: black --check.
+6) Testes: pytest -q.
+7) Smoke da CLI: python -m ogum_lite.cli --help.
+
+Gera:
+- release_check.log       (log textual)
+- release_summary.md      (resumo markdown para Actions Summary)
+
+Retorno:
+- exit code 0 se GO
+- exit code != 0 se NO-GO
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOG = ROOT / "release_check.log"
+SUMMARY = ROOT / "release_summary.md"
+
+
+def run(cmd: list[str], check: bool = False) -> int:
+    with LOG.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n$ {' '.join(cmd)}\n")
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        fh.write(proc.stdout)
+        returncode = proc.returncode
+    if check and returncode != 0:
+        sys.exit(returncode)
+    return returncode
+
+
+def write_summary(lines: list[str]) -> None:
+    SUMMARY.write_text("\n".join(lines), encoding="utf-8")
+
+
+def grep_legacy_pins() -> list[str]:
+    """Procura pins legados que quebram Py 3.12."""
+    patterns = ("pydantic<2", "pydantic-settings<2", "pyyaml<6")
+    offenders: list[str] = []
+    skip_dirs = {".git", ".venv", "venv", "site-packages", "build", "dist", ".mypy_cache"}
+    allowed_suffixes = {".txt", ".cfg", ".toml", ".yml", ".yaml", ".in", ".py"}
+    for path in ROOT.rglob("*"):
+        if path.is_dir():
+            continue
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        if path.suffix.lower() not in allowed_suffixes:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        for pat in patterns:
+            if pat in text:
+                offenders.append(f"{path}: '{pat}'")
+    return sorted(set(offenders))
+
+
+def main() -> int:
+    LOG.write_text("# Ogum-ML — Release 1.0 readiness log\n", encoding="utf-8")
+    summary = ["### Checklist", ""]
+    ok = True
+
+    # 1) Sanidade: ferramentas
+    for tool in ("ruff", "black", "pytest"):
+        if shutil.which(tool) is None:
+            run([sys.executable, "-m", "pip", "install", "--upgrade", tool])
+    summary.append("✅ Ferramentas dev disponíveis (ruff/black/pytest)")
+
+    # 2) Instalação (já feita no workflow), mas validamos import rápido
+    # Se quiser reforçar, descomente a linha abaixo:
+    # run([sys.executable, "-m", "pip", "install", "--no-cache-dir", "-r", "requirements.txt"])
+
+    # 3) Pins legados
+    offenders = grep_legacy_pins()
+    if offenders:
+        ok = False
+        summary.append("❌ Pins legados encontrados:")
+        summary.extend([f"- {o}" for o in offenders])
+    else:
+        summary.append("✅ Sem pins legados (pydantic<2, pydantic-settings<2, pyyaml<6)")
+
+    # 4) Lint
+    rc = run(["ruff", "check", "."], check=False)
+    if rc != 0:
+        ok = False
+        summary.append("❌ Ruff falhou")
+    else:
+        summary.append("✅ Ruff OK")
+
+    # 5) Black
+    rc = run(["black", "--check", "."], check=False)
+    if rc != 0:
+        ok = False
+        summary.append("❌ Black --check falhou")
+    else:
+        summary.append("✅ Black OK")
+
+    # 6) Pytest
+    rc = run(["pytest", "-q"], check=False)
+    if rc != 0:
+        ok = False
+        summary.append("❌ Testes falharam (pytest)")
+    else:
+        summary.append("✅ Testes OK (pytest)")
+
+    # 7) Smoke CLI
+    rc = run([sys.executable, "-m", "ogum_lite.cli", "--help"], check=False)
+    if rc != 0:
+        ok = False
+        summary.append("❌ CLI falhou (python -m ogum_lite.cli --help)")
+    else:
+        summary.append("✅ CLI OK")
+
+    # Resultado final
+    summary.append("")
+    if ok:
+        summary.append("## ✅ Release 1.0 READY (GO)")
+        code = 0
+    else:
+        summary.append("## ❌ Release 1.0 NOT READY (NO-GO)")
+        code = 1
+
+    write_summary(summary)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Release Check GitHub Actions workflow to verify 1.0 readiness on pushes to main and manual dispatch
- implement the `tools/release_check.py` helper script that runs dependency, lint, test, and CLI checks while producing log and summary artifacts
- surface the workflow status badge in the README for quick visibility

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68df3d8604dc8327b4b13b50d68f7b2e