### PR TITLE
Improve dependency detection in release check workflow

### DIFF
--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -33,8 +33,41 @@ jobs:
           echo "--------------------------------------"
 
       - name: Install project deps
+        shell: bash
         run: |
-          pip install --no-cache-dir -r requirements.txt || pip install -r requirements.txt
+          set -euo pipefail
+          echo "PWD: $(pwd)"
+          echo "Árvore (nível 2):"
+          find . -maxdepth 2 -type f -name "requirements*.txt" -print || true
+          echo "---- Conteúdo dos candidates ----"
+          if [ -f requirements.txt ]; then
+            echo ">>> requirements.txt"
+            cat requirements.txt
+          fi
+          if [ -f ogum-ml-lite/requirements.txt ]; then
+            echo ">>> ogum-ml-lite/requirements.txt"
+            cat ogum-ml-lite/requirements.txt
+          fi
+          echo "---------------------------------"
+
+          # Escolha do arquivo
+          REQUIREMENTS=""
+          if [ -f requirements.txt ]; then
+            REQUIREMENTS="requirements.txt"
+          elif [ -f ogum-ml-lite/requirements.txt ]; then
+            REQUIREMENTS="ogum-ml-lite/requirements.txt"
+          else
+            echo "❌ Nenhum requirements.txt encontrado (raiz ou ogum-ml-lite/)."
+            exit 2
+          fi
+
+          echo "Usando arquivo: $REQUIREMENTS"
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --no-cache-dir -r "$REQUIREMENTS"
+
+      - name: Sanity — verificar pins legados
+        run: |
+          ! grep -RInE "pydantic<2|pydantic-settings<2|pyyaml<6" -n . || (echo "❌ Pins legados encontrados"; exit 3)
 
       - name: Install dev tools (ruff/black/pytest) if not included
         run: |


### PR DESCRIPTION
## Summary
- extend the dependency installation step to auto-detect the appropriate requirements file, upgrade pip tooling, and print candidate contents for easier debugging
- add a sanity check to fail when legacy dependency pins are detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3f88dda48327bc27467679212354